### PR TITLE
feat: implement ride cancellation logic

### DIFF
--- a/backend/src/main/java/com/team27/lucky3/backend/controller/RideController.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/controller/RideController.java
@@ -12,6 +12,7 @@ import com.team27.lucky3.backend.dto.response.RideResponse;
 import com.team27.lucky3.backend.dto.response.RoutePointResponse;
 import com.team27.lucky3.backend.entity.enums.RideStatus;
 import com.team27.lucky3.backend.exception.ResourceNotFoundException;
+import com.team27.lucky3.backend.service.RideService;
 import com.team27.lucky3.backend.util.DummyData;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -35,6 +36,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Validated
 public class RideController {
+
+    private final RideService rideService;
 
     // 2.1.2 Ride estimation on the map page (unregistered user)
     @PostMapping("/estimate")
@@ -107,8 +110,7 @@ public class RideController {
             @PathVariable @Min(1) Long id,
             @Valid @RequestBody RideCancellationRequest request) {
         if (id == 404) throw new ResourceNotFoundException("Ride not found");
-        RideResponse response = DummyData.createDummyRideResponse(id, 10L, 123L, RideStatus.CANCELLED);
-        response.setRejectionReason(request.getReason());
+        RideResponse response = rideService.cancelRide(id, request.getReason());
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/team27/lucky3/backend/entity/Ride.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/entity/Ride.java
@@ -31,6 +31,8 @@ public class Ride {
     private RideStatus status;
 
     private Boolean panicPressed;
+
+    @Column(name = "rejection_reason")
     private String rejectionReason;
 
     private boolean petTransport;


### PR DESCRIPTION
Implements the full logic for ride cancellation by both drivers and passengers as defined in specification section 2.5.

Changes include:
- Updated `RideServiceImpl` to enforce cancellation rules:
  - Drivers must provide a reason and cannot cancel if the ride has already started (passengers are inside).
  - Passengers cannot cancel a scheduled ride within 10 minutes of the scheduled start time.
- Updated `RideController` to expose the cancellation endpoint and pass the cancellation reason.
- Added state transitions to CANCELLED and persistence of the rejection reason.
- Drivers requesting inactivity after a cancellation are now handled correctly.

Closes: #92, #97, #98, #99, #100, #101, #102, #105