### PR TITLE
feat: implement ride stop and price recalculation

### DIFF
--- a/backend/src/main/java/com/team27/lucky3/backend/controller/RideController.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/controller/RideController.java
@@ -130,8 +130,7 @@ public class RideController {
             @PathVariable @Min(1) Long id,
             @Valid @RequestBody RideStopRequest request) {
         if (id == 404) throw new ResourceNotFoundException("Ride not found");
-        RideResponse response = DummyData.createDummyRideResponse(id, 10L, 123L, RideStatus.FINISHED);
-        response.setDestination(request.getStopLocation());
+        RideResponse response = rideService.stopRide(id, request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/team27/lucky3/backend/service/RideService.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/service/RideService.java
@@ -3,6 +3,7 @@ package com.team27.lucky3.backend.service;
 import com.team27.lucky3.backend.dto.request.CreateRideRequest;
 import com.team27.lucky3.backend.dto.request.EndRideRequest;
 import com.team27.lucky3.backend.dto.request.RidePanicRequest;
+import com.team27.lucky3.backend.dto.request.RideStopRequest;
 import com.team27.lucky3.backend.dto.response.RideResponse;
 import com.team27.lucky3.backend.entity.Ride;
 
@@ -12,6 +13,7 @@ public interface RideService {
     RideResponse startRide(Long id);
     RideResponse endRide(Long id, EndRideRequest request);
     RideResponse cancelRide(Long id, String reason);
+    RideResponse stopRide(Long id, RideStopRequest request);
     RideResponse panicRide(Long id, RidePanicRequest request);
     Ride findById(Long id);
 }


### PR DESCRIPTION
Implements the functionality for a driver to stop a ride while it is in progress, as defined in specification section 2.6.5.

Changes include:
- Implemented `stopRide` in `RideServiceImpl` to handle early ride termination.
- Added logic to update the ride destination to the specific location where the stop occurred.
- Implemented price recalculation based on the actual distance traveled (using Haversine formula) and the vehicle type base price.
- Added validation to ensure only the assigned driver can stop the ride and only when it is in progress.
- Updated `RideController` to connect the stop endpoint to the service logic.
- Ensured driver inactivity requests are processed immediately after the ride is stopped.