### PR TITLE
feat: implement panic button functionality

### DIFF
--- a/backend/src/main/java/com/team27/lucky3/backend/controller/PanicController.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/controller/PanicController.java
@@ -5,10 +5,14 @@ import com.team27.lucky3.backend.dto.response.RideResponse;
 import com.team27.lucky3.backend.dto.response.UserResponse;
 import com.team27.lucky3.backend.entity.enums.RideStatus;
 import com.team27.lucky3.backend.entity.enums.UserRole;
+import com.team27.lucky3.backend.service.PanicService;
 import com.team27.lucky3.backend.util.DummyData;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,13 +27,24 @@ import java.util.List;
 @Validated
 public class PanicController {
 
+    private final PanicService panicService;
+
     // 2.6.3 Admin views panic notifications
+    /* TODO: Check what is better
     @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<PanicResponse>> getPanicNotifications() {
         RideResponse ride = DummyData.createDummyRideResponse(1L, 10L, 20L, RideStatus.PANIC);
         UserResponse user = new UserResponse(20L, "Panic", "User", "p@gmail.com", "url", UserRole.PASSENGER, "123", "Addr");
 
         PanicResponse panic = new PanicResponse(1L, user, ride, LocalDateTime.now(), "Driver is driving too fast!");
         return ResponseEntity.ok(List.of(panic));
+    }*/
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Page<PanicResponse>> getPanics(Pageable pageable) {
+        Page<PanicResponse> response = panicService.findAll(pageable);
+        return ResponseEntity.ok(panicService.findAll(pageable));
     }
 }

--- a/backend/src/main/java/com/team27/lucky3/backend/controller/RideController.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/controller/RideController.java
@@ -119,9 +119,7 @@ public class RideController {
             @PathVariable @Min(1) Long id,
             @Valid @RequestBody RidePanicRequest request) {
         if (id == 404) throw new ResourceNotFoundException("Ride not found");
-        RideResponse response = DummyData.createDummyRideResponse(id, 10L, 123L, RideStatus.PANIC);
-        response.setRejectionReason(request.getReason());
-        response.setPanicPressed(true);
+        RideResponse response = rideService.panicRide(id, request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/team27/lucky3/backend/service/PanicService.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/service/PanicService.java
@@ -1,0 +1,9 @@
+package com.team27.lucky3.backend.service;
+
+import com.team27.lucky3.backend.dto.response.PanicResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PanicService {
+    Page<PanicResponse> findAll(Pageable pageable);
+}

--- a/backend/src/main/java/com/team27/lucky3/backend/service/impl/PanicServiceImpl.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/service/impl/PanicServiceImpl.java
@@ -1,0 +1,103 @@
+package com.team27.lucky3.backend.service.impl;
+
+import com.team27.lucky3.backend.dto.LocationDto;
+import com.team27.lucky3.backend.dto.request.VehicleInformation;
+import com.team27.lucky3.backend.dto.response.*;
+import com.team27.lucky3.backend.entity.Panic;
+import com.team27.lucky3.backend.entity.Ride;
+import com.team27.lucky3.backend.entity.Vehicle;
+import com.team27.lucky3.backend.repository.PanicRepository;
+import com.team27.lucky3.backend.repository.VehicleRepository;
+import com.team27.lucky3.backend.service.PanicService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PanicServiceImpl implements PanicService {
+
+    private final PanicRepository panicRepository;
+    private final VehicleRepository vehicleRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PanicResponse> findAll(Pageable pageable) {
+        Page<Panic> panics = panicRepository.findAll(pageable);
+        return panics.map(this::mapToResponse);
+    }
+
+    private PanicResponse mapToResponse(Panic panic) {
+        PanicResponse response = new PanicResponse();
+        response.setId(panic.getId());
+        response.setTime(panic.getTimestamp());
+        response.setReason(panic.getReason());
+
+        if (panic.getUser() != null) {
+            response.setUser(new UserResponse(
+                    panic.getUser().getId(),
+                    panic.getUser().getName(),
+                    panic.getUser().getSurname(),
+                    panic.getUser().getEmail(),
+                    panic.getUser().getProfilePictureUrl(),
+                    panic.getUser().getRole(),
+                    panic.getUser().getPhoneNumber(),
+                    panic.getUser().getAddress()
+            ));
+        }
+
+        if (panic.getRide() != null) {
+            response.setRide(mapRideToResponse(panic.getRide()));
+        }
+
+        return response;
+    }
+
+    // Independent mapper to avoid circular dependency with RideService
+    private RideResponse mapRideToResponse(Ride ride) {
+        RideResponse res = new RideResponse();
+        res.setId(ride.getId());
+        res.setStartTime(ride.getStartTime());
+        res.setEndTime(ride.getEndTime());
+        res.setTotalCost(ride.getTotalCost());
+        res.setEstimatedCost(ride.getEstimatedCost());
+        res.setDistanceKm(ride.getDistance());
+        res.setStatus(ride.getStatus());
+        res.setPanicPressed(Boolean.TRUE.equals(ride.getPanicPressed()));
+        res.setRejectionReason(ride.getRejectionReason());
+        res.setPetTransport(ride.isPetTransport());
+        res.setBabyTransport(ride.isBabyTransport());
+        res.setVehicleType(ride.getRequestedVehicleType());
+
+        if (ride.getStartLocation() != null) {
+            res.setDeparture(new LocationDto(ride.getStartLocation().getAddress(), ride.getStartLocation().getLatitude(), ride.getStartLocation().getLongitude()));
+        }
+        if (ride.getEndLocation() != null) {
+            res.setDestination(new LocationDto(ride.getEndLocation().getAddress(), ride.getEndLocation().getLatitude(), ride.getEndLocation().getLongitude()));
+        }
+        res.setScheduledTime(ride.getScheduledTime());
+
+        if (ride.getDriver() != null) {
+            Vehicle vehicle = vehicleRepository.findByDriverId(ride.getDriver().getId()).orElse(null);
+            VehicleInformation vInfo = null;
+            if(vehicle != null) {
+                vInfo = new VehicleInformation(vehicle.getModel(), vehicle.getVehicleType(), vehicle.getLicensePlates(), vehicle.getSeatCount(), vehicle.isBabyTransport(), vehicle.isPetTransport(), ride.getDriver().getId());
+            }
+            DriverResponse dr = new DriverResponse(ride.getDriver().getId(), ride.getDriver().getName(), ride.getDriver().getSurname(), ride.getDriver().getEmail(), ride.getDriver().getProfilePictureUrl(), ride.getDriver().getRole(), ride.getDriver().getPhoneNumber(), ride.getDriver().getAddress(), vInfo, ride.getDriver().isActive(), "0h 0m");
+            res.setDriver(dr);
+        }
+
+        if (ride.getPassengers() != null) {
+            List<UserResponse> passengers = ride.getPassengers().stream()
+                    .map(p -> new UserResponse(p.getId(), p.getName(), p.getSurname(), p.getEmail(), p.getProfilePictureUrl(), p.getRole(), p.getPhoneNumber(), p.getAddress()))
+                    .collect(Collectors.toList());
+            res.setPassengers(passengers);
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
Implements the full "Panic Button" feature allowing ride participants to emergency stop a ride and administrators to view the panic history.

Changes include:
- Added `PanicService` and `PanicServiceImpl` to handle panic log retrieval and mapping to `PanicResponse` DTOs.
- Updated `PanicController` to expose the GET endpoint for administrators to view paginated panic history.
- Updated `RideServiceImpl` to implement `panicRide`:
  - Stops the ride immediately and updates status to PANIC.
  - Records the user who pressed it, the time, and the reason.
  - Validates that the ride is in progress and the user is a participant.
- Updated `RideController` to expose the panic action endpoint.
- Ensured correct handling of driver inactivity if a panic occurs.