### PR TITLE
replace Recycler view with list view & remove authinterceptor

### DIFF
--- a/mobile/app/src/main/java/com/example/mobile/services/RideService.java
+++ b/mobile/app/src/main/java/com/example/mobile/services/RideService.java
@@ -8,6 +8,7 @@ import com.example.mobile.models.RideResponse;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
+import retrofit2.http.Header;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
@@ -21,7 +22,7 @@ public interface RideService {
      * Get ride by ID
      */
     @GET("api/rides/{id}")
-    Call<RideResponse> getRide(@Path("id") long id);
+    Call<RideResponse> getRide(@Path("id") long id, @Header("Authorization") String token);
     
     /**
      * Get ride history with pagination and filters
@@ -35,6 +36,7 @@ public interface RideService {
         @Query("toDate") String toDate,
         @Query("page") Integer page,
         @Query("size") Integer size,
-        @Query("sort") String sort
+        @Query("sort") String sort,
+        @Header("Authorization") String token
     );
 }

--- a/mobile/app/src/main/java/com/example/mobile/ui/driver/RideDetailsFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/driver/RideDetailsFragment.java
@@ -16,7 +16,6 @@ import com.example.mobile.R;
 import com.example.mobile.databinding.FragmentRideDetailsBinding;
 import com.example.mobile.models.LocationDto;
 import com.example.mobile.models.RideResponse;
-import com.example.mobile.services.RideService;
 import com.example.mobile.ui.maps.RideMapRenderer;
 import com.example.mobile.utils.ClientUtils;
 import com.example.mobile.utils.SharedPreferencesManager;
@@ -39,7 +38,6 @@ public class RideDetailsFragment extends Fragment {
     private static final String TAG = "RideDetails";
     private FragmentRideDetailsBinding binding;
     private SharedPreferencesManager preferencesManager;
-    private RideService rideService;
     
     private RideResponse ride;
     private long rideId = -1;
@@ -54,7 +52,6 @@ public class RideDetailsFragment extends Fragment {
         View root = binding.getRoot();
 
         preferencesManager = new SharedPreferencesManager(requireContext());
-        rideService = ClientUtils.getAuthenticatedRideService(preferencesManager);
 
         // Initialize map
         mapView = root.findViewById(R.id.map_view);
@@ -83,7 +80,8 @@ public class RideDetailsFragment extends Fragment {
     }
     
     private void loadRideDetails() {
-        rideService.getRide(rideId).enqueue(new Callback<RideResponse>() {
+        String token = "Bearer " + preferencesManager.getToken();
+        ClientUtils.rideService.getRide(rideId, token).enqueue(new Callback<RideResponse>() {
             @Override
             public void onResponse(Call<RideResponse> call, Response<RideResponse> response) {
                 if (response.isSuccessful() && response.body() != null) {

--- a/mobile/app/src/main/java/com/example/mobile/ui/driver/RideHistoryAdapter.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/driver/RideHistoryAdapter.java
@@ -1,36 +1,69 @@
 package com.example.mobile.ui.driver;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.BaseAdapter;
 import android.widget.TextView;
-import androidx.annotation.NonNull;
+
 import androidx.navigation.Navigation;
-import androidx.recyclerview.widget.RecyclerView;
+
 import com.example.mobile.R;
+
 import java.util.List;
 import java.util.Locale;
 
-public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.ViewHolder> {
+public class RideHistoryAdapter extends BaseAdapter {
 
     private final List<RideHistoryItem> items;
+    private final LayoutInflater inflater;
 
-    public RideHistoryAdapter(List<RideHistoryItem> items) {
+    public RideHistoryAdapter(Context context, List<RideHistoryItem> items) {
         this.items = items;
-    }
-
-    @NonNull
-    @Override
-    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.item_ride_history, parent, false);
-        return new ViewHolder(view);
+        this.inflater = LayoutInflater.from(context);
     }
 
     @Override
-    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        RideHistoryItem item = items.get(position);
+    public int getCount() {
+        return items.size();
+    }
+
+    @Override
+    public RideHistoryItem getItem(int position) {
+        return items.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return items.get(position).rideId;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ViewHolder holder;
+
+        if (convertView == null) {
+            convertView = inflater.inflate(R.layout.item_ride_history, parent, false);
+            holder = new ViewHolder();
+            holder.startDate = convertView.findViewById(R.id.start_date);
+            holder.startTime = convertView.findViewById(R.id.start_time);
+            holder.endDate = convertView.findViewById(R.id.end_date);
+            holder.endTime = convertView.findViewById(R.id.end_time);
+            holder.pickupAddress = convertView.findViewById(R.id.pickup_address);
+            holder.dropoffAddress = convertView.findViewById(R.id.dropoff_address);
+            holder.passengerCount = convertView.findViewById(R.id.passenger_count);
+            holder.distance = convertView.findViewById(R.id.distance);
+            holder.duration = convertView.findViewById(R.id.duration);
+            holder.price = convertView.findViewById(R.id.price);
+            convertView.setTag(holder);
+        } else {
+            holder = (ViewHolder) convertView.getTag();
+        }
+
+        RideHistoryItem item = getItem(position);
+
         holder.startDate.setText(item.startDate);
         holder.startTime.setText(item.startTime);
         holder.endDate.setText(item.endDate);
@@ -40,49 +73,31 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         holder.passengerCount.setText(String.valueOf(item.passengerCount));
         holder.distance.setText(item.distance);
         holder.duration.setText(item.duration);
-        
-        // Set price
+
         if (holder.price != null) {
             holder.price.setText(String.format(Locale.US, "%.2f RSD", item.price));
         }
 
-        holder.itemView.setOnClickListener(v -> {
+        convertView.setOnClickListener(v -> {
             Bundle args = new Bundle();
             args.putLong("rideId", item.rideId);
             Navigation.findNavController(v).navigate(R.id.action_nav_driver_dashboard_to_nav_ride_details, args);
         });
+
+        return convertView;
     }
 
-    @Override
-    public int getItemCount() {
-        return items.size();
-    }
-
-    public static class ViewHolder extends RecyclerView.ViewHolder {
-        public final TextView startDate;
-        public final TextView startTime;
-        public final TextView endDate;
-        public final TextView endTime;
-        public final TextView pickupAddress;
-        public final TextView dropoffAddress;
-        public final TextView passengerCount;
-        public final TextView distance;
-        public final TextView duration;
-        public final TextView price;
-
-        public ViewHolder(View view) {
-            super(view);
-            startDate = view.findViewById(R.id.start_date);
-            startTime = view.findViewById(R.id.start_time);
-            endDate = view.findViewById(R.id.end_date);
-            endTime = view.findViewById(R.id.end_time);
-            pickupAddress = view.findViewById(R.id.pickup_address);
-            dropoffAddress = view.findViewById(R.id.dropoff_address);
-            passengerCount = view.findViewById(R.id.passenger_count);
-            distance = view.findViewById(R.id.distance);
-            duration = view.findViewById(R.id.duration);
-            price = view.findViewById(R.id.price);
-        }
+    private static class ViewHolder {
+        TextView startDate;
+        TextView startTime;
+        TextView endDate;
+        TextView endTime;
+        TextView pickupAddress;
+        TextView dropoffAddress;
+        TextView passengerCount;
+        TextView distance;
+        TextView duration;
+        TextView price;
     }
 
     public static class RideHistoryItem {
@@ -101,10 +116,10 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         public RideHistoryItem(String startDate, String startTime, String endDate, String endTime,
                                String pickupAddress, String dropoffAddress, int passengerCount,
                                String distance, String duration) {
-            this(0, startDate, startTime, endDate, endTime, pickupAddress, dropoffAddress, 
+            this(0, startDate, startTime, endDate, endTime, pickupAddress, dropoffAddress,
                  passengerCount, distance, duration, 0);
         }
-        
+
         public RideHistoryItem(long rideId, String startDate, String startTime, String endDate, String endTime,
                                String pickupAddress, String dropoffAddress, int passengerCount,
                                String distance, String duration, double price) {

--- a/mobile/app/src/main/java/com/example/mobile/utils/ClientUtils.java
+++ b/mobile/app/src/main/java/com/example/mobile/utils/ClientUtils.java
@@ -70,12 +70,7 @@ public class ClientUtils {
             .build();
 
     /**
-     * OkHttpClient with authentication interceptor.
-     */
-    private static OkHttpClient authHttpClient = null;
-
-    /**
-     * Retrofit instance without authentication.
+     * Retrofit instance.
      */
     private static final Retrofit retrofit = new Retrofit.Builder()
             .baseUrl(SERVICE_API_PATH)
@@ -84,12 +79,7 @@ public class ClientUtils {
             .build();
 
     /**
-     * Retrofit instance with authentication (lazy initialized).
-     */
-    private static Retrofit authRetrofit = null;
-
-    /**
-     * UserService instance (without auth - for login/register).
+     * UserService instance.
      */
     public static final UserService userService = retrofit.create(UserService.class);
 
@@ -99,137 +89,17 @@ public class ClientUtils {
 
     public static final DriverService driverService = retrofit.create(DriverService.class);
     /**
-     * VehicleService instance (without auth - for public vehicle data).
+     * VehicleService instance.
      */
     public static final VehicleService vehicleService = retrofit.create(VehicleService.class);
 
     /**
-     * RideService instance (without auth - for estimation).
+     * RideService instance.
      */
     public static final RideService rideService = retrofit.create(RideService.class);
 
     /**
-     * Authenticated UserService instance (lazy initialized).
-     */
-    private static UserService authenticatedUserService = null;
-
-    /**
-     * Authenticated VehicleService instance (lazy initialized).
-     */
-    private static VehicleService authenticatedVehicleService = null;
-    
-    /**
-     * Authenticated RideService instance (lazy initialized).
-     */
-    private static RideService authenticatedRideService = null;
-    
-    /**
-     * Authenticated DriverService instance (lazy initialized).
-     */
-    private static DriverService authenticatedDriverService = null;
-
-    /**
-     * Creates and returns an OkHttpClient with the AuthInterceptor.
-     * 
-     * @param preferencesManager SharedPreferencesManager to retrieve JWT token
-     * @return OkHttpClient configured with authentication
-     */
-    public static OkHttpClient getAuthenticatedClient(SharedPreferencesManager preferencesManager) {
-        if (authHttpClient == null) {
-            authHttpClient = new OkHttpClient.Builder()
-                    .connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS)
-                    .readTimeout(READ_TIMEOUT, TimeUnit.SECONDS)
-                    .writeTimeout(WRITE_TIMEOUT, TimeUnit.SECONDS)
-                    .addInterceptor(new AuthInterceptor(preferencesManager))
-                    .addInterceptor(loggingInterceptor)
-                    .build();
-        }
-        return authHttpClient;
-    }
-
-    /**
-     * Creates and returns a Retrofit instance with authentication.
-     * 
-     * @param preferencesManager SharedPreferencesManager to retrieve JWT token
-     * @return Retrofit instance configured with authentication
-     */
-    public static Retrofit getAuthenticatedRetrofit(SharedPreferencesManager preferencesManager) {
-        if (authRetrofit == null) {
-            authRetrofit = new Retrofit.Builder()
-                    .baseUrl(SERVICE_API_PATH)
-                    .client(getAuthenticatedClient(preferencesManager))
-                    .addConverterFactory(GsonConverterFactory.create(gson))
-                    .build();
-        }
-        return authRetrofit;
-    }
-
-    /**
-     * Gets the authenticated UserService.
-     * 
-     * @param preferencesManager SharedPreferencesManager to retrieve JWT token
-     * @return UserService with authentication headers
-     */
-    public static UserService getAuthenticatedUserService(SharedPreferencesManager preferencesManager) {
-        if (authenticatedUserService == null) {
-            authenticatedUserService = getAuthenticatedRetrofit(preferencesManager).create(UserService.class);
-        }
-        return authenticatedUserService;
-    }
-
-    /**
-     * Gets the authenticated VehicleService.
-     * 
-     * @param preferencesManager SharedPreferencesManager to retrieve JWT token
-     * @return VehicleService with authentication headers
-     */
-    public static VehicleService getAuthenticatedVehicleService(SharedPreferencesManager preferencesManager) {
-        if (authenticatedVehicleService == null) {
-            authenticatedVehicleService = getAuthenticatedRetrofit(preferencesManager).create(VehicleService.class);
-        }
-        return authenticatedVehicleService;
-    }
-    
-    /**
-     * Gets the authenticated RideService.
-     * 
-     * @param preferencesManager SharedPreferencesManager to retrieve JWT token
-     * @return RideService with authentication headers
-     */
-    public static RideService getAuthenticatedRideService(SharedPreferencesManager preferencesManager) {
-        if (authenticatedRideService == null) {
-            authenticatedRideService = getAuthenticatedRetrofit(preferencesManager).create(RideService.class);
-        }
-        return authenticatedRideService;
-    }
-    
-    /**
-     * Gets the authenticated DriverService.
-     * 
-     * @param preferencesManager SharedPreferencesManager to retrieve JWT token
-     * @return DriverService with authentication headers
-     */
-    public static DriverService getAuthenticatedDriverService(SharedPreferencesManager preferencesManager) {
-        if (authenticatedDriverService == null) {
-            authenticatedDriverService = getAuthenticatedRetrofit(preferencesManager).create(DriverService.class);
-        }
-        return authenticatedDriverService;
-    }
-
-    /**
-     * Resets authenticated clients (call on logout).
-     */
-    public static void resetAuthenticatedClients() {
-        authHttpClient = null;
-        authRetrofit = null;
-        authenticatedUserService = null;
-        authenticatedVehicleService = null;
-        authenticatedRideService = null;
-        authenticatedDriverService = null;
-    }
-
-    /**
-     * Returns the base Retrofit instance (no auth).
+     * Returns the base Retrofit instance.
      */
     public static Retrofit getRetrofit() {
         return retrofit;

--- a/mobile/app/src/main/res/layout/fragment_driver_dashboard.xml
+++ b/mobile/app/src/main/res/layout/fragment_driver_dashboard.xml
@@ -481,13 +481,12 @@
                         android:layout_marginBottom="8dp"/>
 
                     <!-- Ride History List -->
-                    <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/ride_history_recycler"
+                    <ListView
+                        android:id="@+id/ride_history_list"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:nestedScrollingEnabled="false"
-                        tools:listitem="@layout/item_ride_history"
-                        tools:itemCount="3"/>
+                        android:divider="@null"
+                        android:dividerHeight="0dp"/>
                 </LinearLayout>
             </HorizontalScrollView>
 

--- a/mobile/app/src/main/res/layout/fragment_driver_ride_history.xml
+++ b/mobile/app/src/main/res/layout/fragment_driver_ride_history.xml
@@ -243,14 +243,15 @@
         app:layout_constraintTop_toBottomOf="@id/stats_scroll"
         app:layout_constraintStart_toStartOf="parent"/>
 
-    <!-- Placeholder for RecyclerView -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rides_recycler_view"
+    <!-- Placeholder for ListView -->
+    <ListView
+        android:id="@+id/rides_list_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="12dp"
+        android:divider="@null"
+        android:dividerHeight="0dp"
         app:layout_constraintTop_toBottomOf="@id/history_title"
-        app:layout_constraintBottom_toBottomOf="parent"
-        tools:listitem="@layout/item_ride_history"/>
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This pull request refactors the driver ride history and dashboard fragments in the mobile app to improve code maintainability and UI consistency. The main changes include switching from `RecyclerView` to `ListView` for ride history lists, updating adapters accordingly, and simplifying how authenticated services are accessed. Additionally, API calls now consistently include an authorization header.

Key changes:

**API and Service Layer Updates:**
- Updated the `RideService` interface to require an `Authorization` header for `getRide` and `getRidesHistory` endpoints, ensuring all ride-related API calls are authenticated. [[1]](diffhunk://#diff-7da4bf652e78a7fc49a91a6b0b2c7d9ceb72750ef86c23b755bf4e3e85f3095bR11) [[2]](diffhunk://#diff-7da4bf652e78a7fc49a91a6b0b2c7d9ceb72750ef86c23b755bf4e3e85f3095bL24-R25) [[3]](diffhunk://#diff-7da4bf652e78a7fc49a91a6b0b2c7d9ceb72750ef86c23b755bf4e3e85f3095bL38-R40)

**UI Refactor: RecyclerView to ListView**
- Replaced `RecyclerView` with `ListView` in both `DriverDashboardFragment` and `DriverRideHistoryFragment` for displaying ride history, and updated the corresponding setup methods. [[1]](diffhunk://#diff-b9ecf23ad68445ff4975f4c36582a1a6530bedf856b4d233452a60b04587ad20L14-L23) [[2]](diffhunk://#diff-b9ecf23ad68445ff4975f4c36582a1a6530bedf856b4d233452a60b04587ad20L86-R80) [[3]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cR8-L23) [[4]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL87-R82) [[5]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL145-L174)
- Refactored the `RidesAdapter` from extending `RecyclerView.Adapter` to `BaseAdapter`, with necessary changes to item click handling and view binding. [[1]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL399-R441) [[2]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL490-R505) [[3]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL520-R537)

**Service Access Simplification:**
- Removed instance variables for `RideService` and `DriverService` in favor of using `ClientUtils.rideService` and `ClientUtils.driverService` directly, reducing boilerplate and potential for errors. [[1]](diffhunk://#diff-b9ecf23ad68445ff4975f4c36582a1a6530bedf856b4d233452a60b04587ad20L45-L46) [[2]](diffhunk://#diff-b9ecf23ad68445ff4975f4c36582a1a6530bedf856b4d233452a60b04587ad20L72-L73) [[3]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL44-L45) [[4]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL74-L75) [[5]](diffhunk://#diff-e6b3b2a69fe10fcf8c2ea7000eac81672d4822da97800a411f2cb6a913bb6c6dL19) [[6]](diffhunk://#diff-e6b3b2a69fe10fcf8c2ea7000eac81672d4822da97800a411f2cb6a913bb6c6dL42)

**API Call Adjustments:**
- Updated all ride and driver stats API calls in both fragments to pass the authorization token explicitly and use the new service access pattern. [[1]](diffhunk://#diff-b9ecf23ad68445ff4975f4c36582a1a6530bedf856b4d233452a60b04587ad20L227-R219) [[2]](diffhunk://#diff-b9ecf23ad68445ff4975f4c36582a1a6530bedf856b4d233452a60b04587ad20L261-R263) [[3]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL183-R174) [[4]](diffhunk://#diff-2cdd2ed776ae36739ecff788166cfe2f0df78c121578363ff9fa417c7a90223cL219-R220)

**List Scrolling and Pagination:**
- Replaced `RecyclerView.OnScrollListener` with `AbsListView.OnScrollListener` for pagination logic, ensuring infinite scroll works with `ListView`.

These changes collectively modernize the codebase, enforce authentication, and standardize UI components for driver ride history features.

Closes #323 
