### PR TITLE
feature 2.8 reviews -- implement full selenium tests - login -> ride history -> review

### DIFF
--- a/backend/src/test/java/com/team27/lucky3/e2e/pages/PassengerRideHistoryPage.java
+++ b/backend/src/test/java/com/team27/lucky3/e2e/pages/PassengerRideHistoryPage.java
@@ -1,0 +1,225 @@
+package com.team27.lucky3.e2e.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Page object for the passenger ride history page at /passenger/ride-history.
+ * Handles ride table interactions, reviewable ride detection, and the "Leave a Review" button.
+ */
+public class PassengerRideHistoryPage {
+
+    private WebDriver driver;
+    private WebDriverWait wait;
+
+    private static final String URL = "http://localhost:4200/passenger/ride-history";
+
+    // Status filter buttons
+    @FindBy(css = ".flex.gap-2.bg-gray-900 button")
+    private List<WebElement> statusFilterButtons;
+
+    // Table rows in the rides table
+    @FindBy(css = "app-rides-table table tbody tr")
+    private List<WebElement> rideRows;
+
+    // Selected ride detail panel header
+    @FindBy(css = "h3.text-lg.font-semibold")
+    private WebElement rideDetailsHeading;
+
+    // "Leave a Review" button in the selected ride detail panel
+    @FindBy(xpath = "//button[contains(text(), 'Leave a Review')]")
+    private WebElement leaveReviewButton;
+
+    // "Order Again" button (to confirm detail panel is showing)
+    @FindBy(xpath = "//button[contains(text(), 'Order Again')]")
+    private WebElement orderAgainButton;
+
+    // Close details button
+    @FindBy(css = ".p-1\\.5.rounded-lg.bg-gray-700")
+    private WebElement closeDetailsButton;
+
+    public PassengerRideHistoryPage(WebDriver driver) {
+        this.driver = driver;
+        this.wait = new WebDriverWait(driver, Duration.ofSeconds(15));
+        PageFactory.initElements(driver, this);
+    }
+
+    /**
+     * Navigates directly to the ride history page.
+     */
+    public void navigateTo() {
+        driver.get(URL);
+        waitForTableToLoad();
+    }
+
+    /**
+     * Waits until the ride table is visible and has loaded.
+     */
+    public void waitForTableToLoad() {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(
+                By.cssSelector("app-rides-table table")));
+        // Give a moment for rows to render
+        wait.until(ExpectedConditions.presenceOfAllElementsLocatedBy(
+                By.cssSelector("app-rides-table table tbody tr")));
+    }
+
+    /**
+     * Returns all ride rows in the table.
+     */
+    public List<WebElement> getRideRows() {
+        wait.until(ExpectedConditions.presenceOfAllElementsLocatedBy(
+                By.cssSelector("app-rides-table table tbody tr")));
+        return driver.findElements(By.cssSelector("app-rides-table table tbody tr"));
+    }
+
+    /**
+     * Returns only the reviewable ride rows (those with the blue box-shadow styling).
+     */
+    public List<WebElement> getReviewableRideRows() {
+        return driver.findElements(By.cssSelector("app-rides-table table tbody tr.reviewable-row"));
+    }
+
+    /**
+     * Checks if there are any reviewable rides in the table.
+     */
+    public boolean hasReviewableRides() {
+        List<WebElement> reviewable = getReviewableRideRows();
+        return !reviewable.isEmpty();
+    }
+
+    /**
+     * Clicks on the first reviewable ride row in the table.
+     */
+    public void clickFirstReviewableRide() {
+        wait.until(ExpectedConditions.presenceOfElementLocated(
+                By.cssSelector("app-rides-table table tbody tr.reviewable-row")));
+        List<WebElement> reviewable = getReviewableRideRows();
+        if (reviewable.isEmpty()) {
+            throw new IllegalStateException("No reviewable rides found in the table.");
+        }
+        reviewable.get(0).click();
+    }
+
+    /**
+     * Clicks on a specific ride row by index (0-based).
+     */
+    public void clickRideRow(int index) {
+        List<WebElement> rows = getRideRows();
+        if (index >= rows.size()) {
+            throw new IndexOutOfBoundsException("Ride row index " + index + " is out of bounds (total: " + rows.size() + ")");
+        }
+        rows.get(index).click();
+    }
+
+    /**
+     * Checks if the ride detail panel is currently visible.
+     */
+    public boolean isDetailPanelVisible() {
+        try {
+            wait.until(ExpectedConditions.visibilityOfElementLocated(
+                    By.xpath("//h3[contains(text(), 'Ride Details')]")));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Waits for the ride detail panel to appear after clicking a ride.
+     */
+    public void waitForDetailPanel() {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(
+                By.xpath("//h3[contains(text(), 'Ride Details')]")));
+    }
+
+    /**
+     * Checks if the "Leave a Review" button is visible in the detail panel.
+     * Uses a shorter timeout (3s) to avoid long waits when the button is expected to be absent.
+     */
+    public boolean isLeaveReviewButtonVisible() {
+        try {
+            WebDriverWait shortWait = new WebDriverWait(driver, Duration.ofSeconds(3));
+            WebElement btn = shortWait.until(ExpectedConditions.visibilityOfElementLocated(
+                    By.xpath("//button[contains(text(), 'Leave a Review')]")));
+            return btn.isDisplayed();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Clicks the "Leave a Review" button in the ride detail panel.
+     * This navigates to /review?rideId=<id> in authenticated mode.
+     */
+    public void clickLeaveReview() {
+        WebElement btn = wait.until(ExpectedConditions.elementToBeClickable(
+                By.xpath("//button[contains(text(), 'Leave a Review')]")));
+        btn.click();
+    }
+
+    /**
+     * Clicks a status filter button by its label text (e.g., "all", "Finished", "Cancelled").
+     */
+    public void clickStatusFilter(String status) {
+        for (WebElement btn : statusFilterButtons) {
+            if (btn.getText().trim().equalsIgnoreCase(status)) {
+                wait.until(ExpectedConditions.elementToBeClickable(btn));
+                btn.click();
+                // Wait a moment for the filter to apply
+                try { Thread.sleep(500); } catch (InterruptedException ignored) {}
+                return;
+            }
+        }
+        throw new IllegalArgumentException("Status filter button not found: " + status);
+    }
+
+    /**
+     * Closes the ride detail panel.
+     */
+    public void closeDetails() {
+        try {
+            wait.until(ExpectedConditions.elementToBeClickable(closeDetailsButton));
+            closeDetailsButton.click();
+        } catch (Exception e) {
+            // Panel may not be open
+        }
+    }
+
+    /**
+     * Gets the number of ride rows in the table.
+     */
+    public int getRideCount() {
+        List<WebElement> rows = getRideRows();
+        // If there's a single row with "No rides found", return 0
+        if (rows.size() == 1) {
+            String text = rows.get(0).getText().trim();
+            if (text.contains("No rides found")) return 0;
+        }
+        return rows.size();
+    }
+
+    /**
+     * Checks if a specific ride row is reviewable (has the reviewable-row class).
+     */
+    public boolean isRideRowReviewable(int index) {
+        List<WebElement> rows = getRideRows();
+        if (index >= rows.size()) return false;
+        String classes = rows.get(index).getAttribute("class");
+        return classes != null && classes.contains("reviewable-row");
+    }
+
+    /**
+     * Waits for the URL to change to the review page.
+     */
+    public void waitForReviewPageNavigation() {
+        wait.until(ExpectedConditions.urlContains("/review"));
+    }
+}

--- a/backend/src/test/java/com/team27/lucky3/e2e/pages/ReviewPage.java
+++ b/backend/src/test/java/com/team27/lucky3/e2e/pages/ReviewPage.java
@@ -56,6 +56,10 @@ public class ReviewPage {
     @FindBy(css = "[data-testid='submit-button']")
     private WebElement submitButton;
 
+    // Cancel button (X icon + "Cancel" text) in the review form
+    @FindBy(xpath = "//button[contains(text(), 'Cancel')]")
+    private WebElement cancelButton;
+
     public ReviewPage(WebDriver driver) {
         this.driver = driver;
         this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
@@ -109,6 +113,14 @@ public class ReviewPage {
     public void clickSubmit() {
         wait.until(ExpectedConditions.elementToBeClickable(submitButton));
         submitButton.click();
+    }
+
+    /**
+     * Clicks the cancel button to go back without submitting.
+     */
+    public void clickCancel() {
+        wait.until(ExpectedConditions.elementToBeClickable(cancelButton));
+        cancelButton.click();
     }
 
     /**

--- a/backend/src/test/java/com/team27/lucky3/e2e/tests/ReviewFromHistoryTest.java
+++ b/backend/src/test/java/com/team27/lucky3/e2e/tests/ReviewFromHistoryTest.java
@@ -1,0 +1,417 @@
+package com.team27.lucky3.e2e.tests;
+
+import com.team27.lucky3.e2e.pages.LoginPage;
+import com.team27.lucky3.e2e.pages.PassengerRideHistoryPage;
+import com.team27.lucky3.e2e.pages.ReviewPage;
+import com.team27.lucky3.e2e.pages.SidebarComponent;
+import org.junit.jupiter.api.*;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * E2E tests for the review feature accessed through the passenger ride history page.
+ * The passenger logs in, navigates to ride history, clicks on a reviewable ride,
+ * then uses the "Leave a Review" button to submit a review.
+ *
+ * These tests run FIRST (before the headless token-based tests) with a visible browser.
+ * Ride 10 is reserved for E2E testing — it belongs to passenger3 (ID 5), has no reviews,
+ * and ended ~6 hours ago (well within the 3-day review window).
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Review via Ride History — Authenticated Flow")
+public class ReviewFromHistoryTest extends BaseTest {
+
+    // Ride 10 belongs to passenger3@example.com (ID 5), finished ~6h ago, no reviews.
+    private static final String PASSENGER3_EMAIL = "passenger3@example.com";
+    private static final String PASSENGER3_PASSWORD = "password";
+    private static final long E2E_RIDE_ID = 10L;
+
+    @BeforeAll
+    static void setupClass() throws Exception {
+        Map<String, String> env = loadEnvFile();
+        // Clean up any leftover reviews from previous runs so tests are repeatable.
+        cleanupReviewsForRide(env, E2E_RIDE_ID);
+    }
+
+    /**
+     * Reads the .env file to get DB credentials.
+     */
+    private static Map<String, String> loadEnvFile() throws IOException {
+        Map<String, String> env = new HashMap<>();
+        Path envFile = Paths.get("").toAbsolutePath().resolve(".env");
+        if (!Files.exists(envFile)) {
+            envFile = Paths.get("").toAbsolutePath().getParent().resolve("backend").resolve(".env");
+        }
+        if (Files.exists(envFile)) {
+            for (String line : Files.readAllLines(envFile)) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) continue;
+                int eq = trimmed.indexOf('=');
+                if (eq > 0) {
+                    env.put(trimmed.substring(0, eq).trim(), trimmed.substring(eq + 1).trim());
+                }
+            }
+        }
+        for (String key : new String[]{"DB_URL", "DB_USERNAME", "DB_PASSWORD"}) {
+            if (!env.containsKey(key) || env.get(key).isBlank()) {
+                String sysVal = System.getenv(key);
+                if (sysVal != null && !sysVal.isBlank()) {
+                    env.put(key, sysVal);
+                }
+            }
+        }
+        return env;
+    }
+
+    /**
+     * Removes reviews for a specific ride directly from the DB via JDBC.
+     */
+    private static void cleanupReviewsForRide(Map<String, String> env, long rideId) throws Exception {
+        String dbUrl = env.get("DB_URL");
+        String dbUser = env.get("DB_USERNAME");
+        String dbPass = env.get("DB_PASSWORD");
+        if (dbUrl == null || dbUser == null || dbPass == null) {
+            System.err.println("Database info is missing, skipping review cleanup.");
+            return;
+        }
+        try (Connection conn = DriverManager.getConnection(dbUrl, dbUser, dbPass);
+             PreparedStatement ps = conn.prepareStatement("DELETE FROM review WHERE ride_id = ?")) {
+            ps.setLong(1, rideId);
+            int deleted = ps.executeUpdate();
+            if (deleted > 0) {
+                System.out.println("Deleted " + deleted + " old reviews for ride " + rideId);
+            }
+        }
+    }
+
+    /**
+     * Helper: Logs in as passenger3, navigates to ride history, and waits for the table to load.
+     */
+    private PassengerRideHistoryPage loginAndGoToRideHistory() {
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.loginAs(PASSENGER3_EMAIL, PASSENGER3_PASSWORD);
+
+        // Wait for post-login navigation to complete (passenger home page)
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger"));
+
+        // Navigate to ride history via sidebar
+        SidebarComponent sidebar = new SidebarComponent(driver);
+        sidebar.navigateToRideHistory();
+
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger/ride-history"));
+
+        PassengerRideHistoryPage historyPage = new PassengerRideHistoryPage(driver);
+        historyPage.waitForTableToLoad();
+        return historyPage;
+    }
+
+    // ========================================================================
+    // Happy Path Tests
+    // ========================================================================
+
+    @Test
+    @Order(1)
+    @DisplayName("Happy Path: Ride history shows reviewable rides with blue highlight")
+    void testRideHistoryShowsReviewableRides() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        // Ride 10 ended ~6h ago with no reviews, so it should show as reviewable.
+        assertTrue(historyPage.hasReviewableRides(),
+                "There should be at least one reviewable ride (ride 10) in the table.");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Happy Path: Clicking a reviewable ride shows the detail panel with 'Leave a Review' button")
+    void testClickReviewableRideShowsLeaveReviewButton() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+
+        assertTrue(historyPage.isDetailPanelVisible(),
+                "The ride detail panel should appear after clicking a ride.");
+        assertTrue(historyPage.isLeaveReviewButtonVisible(),
+                "The 'Leave a Review' button should be visible for a reviewable ride.");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Happy Path: 'Leave a Review' button navigates to review page in authenticated mode")
+    void testLeaveReviewNavigatesToReviewPage() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+        historyPage.clickLeaveReview();
+
+        // Should navigate to /review?rideId=<id>
+        historyPage.waitForReviewPageNavigation();
+        String currentUrl = driver.getCurrentUrl();
+        assertTrue(currentUrl.contains("/review"), "Should navigate to the review page.");
+        assertTrue(currentUrl.contains("rideId="), "URL should contain rideId query parameter.");
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Happy Path: Review form is shown in authenticated mode and accepts ratings")
+    void testReviewFormVisibleInAuthenticatedMode() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+        historyPage.clickLeaveReview();
+        historyPage.waitForReviewPageNavigation();
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        assertTrue(reviewPage.isReviewFormVisible(),
+                "The review form should be visible in authenticated mode.");
+        assertEquals("Rate Your Ride", reviewPage.getPageHeadingText());
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("Happy Path: Submit button disabled until both ratings are set (authenticated mode)")
+    void testSubmitDisabledWithoutRatingsAuthenticated() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+        historyPage.clickLeaveReview();
+        historyPage.waitForReviewPageNavigation();
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        // Initially disabled
+        assertFalse(reviewPage.isSubmitButtonEnabled(),
+                "Submit should be disabled with no ratings.");
+
+        // Only driver rating
+        reviewPage.setDriverRating(4);
+        assertFalse(reviewPage.isSubmitButtonEnabled(),
+                "Submit should still be disabled with only driver rating.");
+
+        // Both ratings set
+        reviewPage.setVehicleRating(3);
+        assertTrue(reviewPage.isSubmitButtonEnabled(),
+                "Submit should be enabled once both ratings are set.");
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Happy Path: Cancel button on review page navigates back to ride history")
+    void testCancelButtonNavigatesBackToRideHistory() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+        historyPage.clickLeaveReview();
+        historyPage.waitForReviewPageNavigation();
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        assertTrue(reviewPage.isReviewFormVisible(),
+                "The review form should be visible before cancelling.");
+
+        // Click the cancel button — should go back to ride history
+        reviewPage.clickCancel();
+
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger/ride-history"));
+
+        assertTrue(driver.getCurrentUrl().contains("/passenger/ride-history"),
+                "Cancel should navigate back to ride history.");
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Negative: Cancel button does not submit any review")
+    void testCancelButtonDoesNotSubmitReview() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+        historyPage.clickLeaveReview();
+        historyPage.waitForReviewPageNavigation();
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        // Set ratings and comment but then cancel instead of submitting
+        reviewPage.setDriverRating(5);
+        reviewPage.setVehicleRating(4);
+        reviewPage.enterComment("This should not be saved");
+        reviewPage.clickCancel();
+
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger/ride-history"));
+
+        // The ride should still be reviewable since we cancelled
+        historyPage = new PassengerRideHistoryPage(driver);
+        historyPage.waitForTableToLoad();
+        assertTrue(historyPage.hasReviewableRides(),
+                "Ride should still be reviewable after cancelling the review.");
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Happy Path: Successfully submit review from ride history (authenticated mode)")
+    void testSubmitReviewFromRideHistory() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        historyPage.clickFirstReviewableRide();
+        historyPage.waitForDetailPanel();
+        historyPage.clickLeaveReview();
+        historyPage.waitForReviewPageNavigation();
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        reviewPage.setDriverRating(5);
+        reviewPage.setVehicleRating(4);
+        reviewPage.enterComment("Excellent ride from history page!");
+        reviewPage.clickSubmit();
+
+        assertTrue(reviewPage.isSuccessMessageVisible(),
+                "Should see a success message after submitting the review.");
+        assertEquals("Thank You!", reviewPage.getSuccessHeadingText());
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("Negative: After submitting review, ride is no longer reviewable in history")
+    void testRideNoLongerReviewableAfterSubmission() {
+        // At this point ride 10 was already reviewed in Order(8).
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        // The "Finished" filter should show non-reviewable ride 10 since it now has a review.
+        historyPage.clickStatusFilter("Finished");
+
+        // Ride 10 was just reviewed, so it should no longer appear as reviewable.
+        int reviewableCount = historyPage.getReviewableRideRows().size();
+        if (historyPage.getRideCount() > 0) {
+            historyPage.clickRideRow(0);
+            historyPage.waitForDetailPanel();
+            System.out.println("Reviewable rides after submission: " + reviewableCount);
+        }
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("Negative: Duplicate review from history shows error")
+    void testDuplicateReviewFromHistory() throws Exception {
+        // The review from Order(8) should still be there, so submitting again should fail.
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.loginAs(PASSENGER3_EMAIL, PASSENGER3_PASSWORD);
+
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger"));
+
+        // Navigate directly to review page for ride 10 (it already has a review)
+        driver.get(BASE_URL + "/review?rideId=" + E2E_RIDE_ID);
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        assertTrue(reviewPage.isReviewFormVisible(),
+                "Form should still be shown for authenticated user.");
+
+        reviewPage.setDriverRating(3);
+        reviewPage.setVehicleRating(3);
+        reviewPage.clickSubmit();
+
+        // Should get an error about already submitted review
+        String errorText = reviewPage.getErrorMessageText();
+        assertTrue(errorText.contains("already submitted"),
+                "Should show 'already submitted' error for duplicate review.");
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("Negative: Non-reviewable ride does not show 'Leave a Review' button")
+    void testNonReviewableRideHasNoReviewButton() {
+        PassengerRideHistoryPage historyPage = loginAndGoToRideHistory();
+
+        // Filter to show cancelled rides — these should never be reviewable.
+        historyPage.clickStatusFilter("Cancelled");
+
+        if (historyPage.getRideCount() > 0) {
+            historyPage.clickRideRow(0);
+            historyPage.waitForDetailPanel();
+
+            assertFalse(historyPage.isLeaveReviewButtonVisible(),
+                    "Cancelled rides should not have a 'Leave a Review' button.");
+        }
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("Happy Path: Comment textarea maxlength enforced in authenticated mode")
+    void testCommentMaxLengthAuthenticated() {
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.loginAs(PASSENGER3_EMAIL, PASSENGER3_PASSWORD);
+
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger"));
+
+        driver.get(BASE_URL + "/review?rideId=" + E2E_RIDE_ID);
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        String longText = "A".repeat(600);
+        reviewPage.enterComment(longText);
+
+        String actualText = reviewPage.getCommentText();
+        assertTrue(actualText.length() <= 500,
+                "Comment should be truncated to 500 characters by the maxlength attribute.");
+    }
+
+    @Test
+    @Order(13)
+    @DisplayName("Happy Path: Validation message shown when ratings are missing")
+    void testValidationMessageInAuthenticatedMode() {
+        LoginPage loginPage = new LoginPage(driver);
+        loginPage.loginAs(PASSENGER3_EMAIL, PASSENGER3_PASSWORD);
+
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(ExpectedConditions.urlContains("/passenger"));
+
+        driver.get(BASE_URL + "/review?rideId=" + E2E_RIDE_ID);
+
+        ReviewPage reviewPage = new ReviewPage(driver);
+        reviewPage.waitForPageToLoad();
+
+        assertTrue(reviewPage.isValidationMessageVisible(),
+                "Validation message should be visible when no ratings are set.");
+        String msg = reviewPage.getValidationMessageText();
+        assertTrue(msg.contains("rate both the driver and vehicle"),
+                "Validation message should mention rating both driver and vehicle.");
+    }
+
+    @AfterAll
+    static void cleanupAfterAll() throws Exception {
+        // Clean up the review created during tests so re-runs start fresh.
+        Map<String, String> env = loadEnvFile();
+        cleanupReviewsForRide(env, E2E_RIDE_ID);
+    }
+}

--- a/backend/src/test/java/com/team27/lucky3/e2e/tests/ReviewTest.java
+++ b/backend/src/test/java/com/team27/lucky3/e2e/tests/ReviewTest.java
@@ -25,12 +25,14 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * These are E2E tests for the ride review feature.
+ * These are E2E tests for the ride review feature using direct token links.
  * Passengers should be able to rate both the driver and the vehicle after a ride.
  * We're testing both successful submissions and various error cases like expired links or missing ratings.
+ *
+ * These tests use direct URL access with review tokens and don't require any UI navigation or login flow.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@DisplayName("Review Page - Rating & Token Validation")
+@DisplayName("Review via Token Link")
 public class ReviewTest extends BaseTest {
 
     // The JWT secret is pulled from the .env file so we don't have to hardcode it.


### PR DESCRIPTION
This pull request introduces a new page object for the passenger ride history page and enhances the review page object to support cancel actions. It also clarifies the scope of the review E2E tests to specify that they use direct token links rather than UI navigation.

**New Page Object for Ride History:**

* Added `PassengerRideHistoryPage` class, encapsulating interactions with the `/passenger/ride-history` page, including ride table handling, reviewable ride detection, and status filter actions.

**Enhancements to Review Page Object:**

* Added a locator and click method for the "Cancel" button in the `ReviewPage` class, enabling tests to cancel review submissions. [[1]](diffhunk://#diff-4bcd3fba0e1d7c37ce3dffbad0a62617e1a7efeba2c78d6d0160c5ab003cd1ffR59-R62) [[2]](diffhunk://#diff-4bcd3fba0e1d7c37ce3dffbad0a62617e1a7efeba2c78d6d0160c5ab003cd1ffR118-R125)

**Test Documentation Improvements:**

* Updated the class-level Javadoc and display name in `ReviewTest` to clarify that these E2E tests use direct URL access with review tokens, not UI navigation or login.