### PR TITLE
Admin can block/unblock users

### DIFF
--- a/mobile/app/src/main/java/com/example/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/example/mobile/MainActivity.java
@@ -112,7 +112,7 @@ public class MainActivity extends AppCompatActivity {
         if (navigationView != null) {
             mAppBarConfiguration = new AppBarConfiguration.Builder(
                     R.id.nav_guest_home, R.id.nav_transform, R.id.nav_reflow, R.id.nav_slideshow, R.id.nav_settings,
-                    R.id.nav_admin_dashboard, R.id.nav_admin_reports, R.id.nav_admin_ride_history, R.id.nav_admin_drivers, R.id.nav_admin_pricing, R.id.nav_admin_profile, R.id.nav_admin_support, R.id.nav_admin_panic,
+                    R.id.nav_admin_dashboard, R.id.nav_admin_reports, R.id.nav_admin_ride_history, R.id.nav_admin_drivers, R.id.nav_admin_pricing, R.id.nav_admin_profile, R.id.nav_admin_support, R.id.nav_admin_panic, R.id.nav_admin_block_users,
                     R.id.nav_passenger_home, R.id.nav_passenger_history, R.id.nav_passenger_profile, R.id.nav_passenger_support, R.id.nav_passenger_favorites,
                     R.id.nav_driver_dashboard, R.id.nav_driver_overview, R.id.nav_driver_profile, R.id.nav_driver_support,
                     R.id.nav_active_ride)

--- a/mobile/app/src/main/java/com/example/mobile/models/BlockUserRequest.java
+++ b/mobile/app/src/main/java/com/example/mobile/models/BlockUserRequest.java
@@ -1,0 +1,36 @@
+package com.example.mobile.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Request DTO for blocking a user.
+ * Contains the email of the user to block and the reason for blocking.
+ */
+public class BlockUserRequest {
+    private String email;
+    private String reason;
+
+    public BlockUserRequest() {
+    }
+
+    public BlockUserRequest(String email, String reason) {
+        this.email = email;
+        this.reason = reason;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/models/BlockUserResponse.java
+++ b/mobile/app/src/main/java/com/example/mobile/models/BlockUserResponse.java
@@ -1,0 +1,28 @@
+package com.example.mobile.models;
+
+/**
+ * Response DTO after unblocking a user.
+ */
+public class BlockUserResponse {
+    private String email;
+    private String message;
+
+    public BlockUserResponse() {
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/models/UserProfile.java
+++ b/mobile/app/src/main/java/com/example/mobile/models/UserProfile.java
@@ -1,0 +1,91 @@
+package com.example.mobile.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Model representing a user profile for administrative purposes (e.g., blocking).
+ */
+public class UserProfile {
+    private String name;
+    private String surname;
+    private String email;
+    private String phoneNumber;
+    private String address;
+    private String imageUrl;
+    
+    @SerializedName("blocked")
+    private boolean isBlocked;
+
+    public UserProfile() {
+    }
+
+    public UserProfile(String name, String surname, String email, String phoneNumber, String address, String imageUrl, boolean isBlocked) {
+        this.name = name;
+        this.surname = surname;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.imageUrl = imageUrl;
+        this.isBlocked = isBlocked;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public boolean isBlocked() {
+        return isBlocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+        isBlocked = blocked;
+    }
+    
+    public String getFullName() {
+        return name + " " + surname;
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/services/AdminUserService.java
+++ b/mobile/app/src/main/java/com/example/mobile/services/AdminUserService.java
@@ -1,0 +1,58 @@
+package com.example.mobile.services;
+
+import com.example.mobile.models.BlockUserRequest;
+import com.example.mobile.models.BlockUserResponse;
+import com.example.mobile.models.UserProfile;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+/**
+ * Retrofit service interface for admin user management (blocking/unblocking).
+ */
+public interface AdminUserService {
+
+    /**
+     * Block a user.
+     * POST /api/admin/users/block
+     */
+    @POST("api/admin/users/block")
+    Call<Void> blockUser(
+            @Header("Authorization") String token,
+            @Body BlockUserRequest request
+    );
+
+    /**
+     * Unblock a user.
+     * POST /api/admin/users/unblock/{email}
+     */
+    @POST("api/admin/users/unblock/{email}")
+    Call<BlockUserResponse> unblockUser(
+            @Header("Authorization") String token,
+            @Path("email") String email
+    );
+
+    /**
+     * Get all blocked users.
+     * GET /api/admin/users/blocked
+     */
+    @GET("api/admin/users/blocked")
+    Call<List<UserProfile>> getBlockedUsers(
+            @Header("Authorization") String token
+    );
+
+    /**
+     * Get all unblocked users.
+     * GET /api/admin/users/unblocked
+     */
+    @GET("api/admin/users/unblocked")
+    Call<List<UserProfile>> getUnblockedUsers(
+            @Header("Authorization") String token
+    );
+}

--- a/mobile/app/src/main/java/com/example/mobile/services/UserService.java
+++ b/mobile/app/src/main/java/com/example/mobile/services/UserService.java
@@ -146,6 +146,19 @@ public interface UserService {
             @Header("Authorization") String token
     );
 
+    /**
+     * Check if user is blocked.
+     * GET /api/users/is-blocked
+     * 
+     * @param id User ID
+     * @return Block reason or empty string
+     */
+    @GET("api/users/is-blocked")
+    Call<okhttp3.ResponseBody> isUserBlocked(
+            @Query("id") Long id,
+            @Header("Authorization") String token
+    );
+
     // ========================== FCM Token Endpoints ==========================
 
     /**

--- a/mobile/app/src/main/java/com/example/mobile/ui/admin/AdminBlockUserAdapter.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/admin/AdminBlockUserAdapter.java
@@ -1,0 +1,88 @@
+package com.example.mobile.ui.admin;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.mobile.R;
+import com.example.mobile.models.UserProfile;
+import com.google.android.material.button.MaterialButton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdminBlockUserAdapter extends RecyclerView.Adapter<AdminBlockUserAdapter.ViewHolder> {
+
+    private List<UserProfile> users = new ArrayList<>();
+    private final OnUserActionListener listener;
+
+    public interface OnUserActionListener {
+        void onBlock(UserProfile user);
+        void onUnblock(UserProfile user);
+    }
+
+    public AdminBlockUserAdapter(OnUserActionListener listener) {
+        this.listener = listener;
+    }
+
+    public void setUsers(List<UserProfile> users) {
+        this.users = users;
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_block_user, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        UserProfile user = users.get(position);
+        holder.bind(user, listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return users.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        ImageView ivAvatar;
+        TextView tvName;
+        TextView tvEmail;
+        MaterialButton btnAction;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            ivAvatar = itemView.findViewById(R.id.iv_user_avatar);
+            tvName = itemView.findViewById(R.id.tv_user_name);
+            tvEmail = itemView.findViewById(R.id.tv_user_email);
+            btnAction = itemView.findViewById(R.id.btn_block_action);
+        }
+
+        public void bind(UserProfile user, OnUserActionListener listener) {
+            tvName.setText(user.getFullName());
+            tvEmail.setText(user.getEmail());
+            
+            // Set avatar (placeholder for now)
+            ivAvatar.setImageResource(R.drawable.avatar);
+
+            if (user.isBlocked()) {
+                btnAction.setText("Unblock");
+                btnAction.setBackgroundColor(itemView.getContext().getResources().getColor(R.color.gray_700));
+                btnAction.setOnClickListener(v -> listener.onUnblock(user));
+            } else {
+                btnAction.setText("Block");
+                btnAction.setBackgroundColor(itemView.getContext().getResources().getColor(R.color.red_500));
+                btnAction.setOnClickListener(v -> listener.onBlock(user));
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/ui/admin/AdminBlockUsersFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/admin/AdminBlockUsersFragment.java
@@ -1,0 +1,217 @@
+package com.example.mobile.ui.admin;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+import com.example.mobile.R;
+import com.example.mobile.databinding.FragmentAdminBlockUsersBinding;
+import com.example.mobile.models.UserProfile;
+import com.example.mobile.utils.NavbarHelper;
+import com.example.mobile.viewmodels.AdminBlockUsersViewModel;
+
+public class AdminBlockUsersFragment extends Fragment implements AdminBlockUserAdapter.OnUserActionListener {
+
+    private FragmentAdminBlockUsersBinding binding;
+    private AdminBlockUsersViewModel viewModel;
+    private AdminBlockUserAdapter adapter;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = FragmentAdminBlockUsersBinding.inflate(inflater, container, false);
+        
+        // Setup navbar
+        NavbarHelper.setup(this, binding.getRoot(), "Block Users");
+        
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        
+        viewModel = new ViewModelProvider(this).get(AdminBlockUsersViewModel.class);
+        
+        setupRecyclerView();
+        setupSearch();
+        setupFilters();
+        observeViewModel();
+        
+        viewModel.loadData();
+    }
+
+    private void setupRecyclerView() {
+        adapter = new AdminBlockUserAdapter(this);
+        binding.rvUsers.setLayoutManager(new LinearLayoutManager(requireContext()));
+        binding.rvUsers.setAdapter(adapter);
+    }
+
+    private void setupSearch() {
+        binding.etSearchUser.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_SEARCH || 
+                (event != null && event.getKeyCode() == KeyEvent.KEYCODE_ENTER)) {
+                viewModel.search(v.getText().toString());
+                return true;
+            }
+            return false;
+        });
+
+        binding.etSearchUser.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (s.length() == 0) {
+                    viewModel.search("");
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+    }
+
+    private void setupFilters() {
+        binding.tvFilterAll.setOnClickListener(v -> {
+            viewModel.setFilter("All");
+            updateFilterStyles("All");
+        });
+        
+        binding.tvFilterBlocked.setOnClickListener(v -> {
+            viewModel.setFilter("Blocked");
+            updateFilterStyles("Blocked");
+        });
+        
+        binding.tvFilterUnblocked.setOnClickListener(v -> {
+            viewModel.setFilter("Unblocked");
+            updateFilterStyles("Unblocked");
+        });
+    }
+
+    private void updateFilterStyles(String activeFilter) {
+        // Reset all
+        resetFilterStyle(binding.tvFilterAll);
+        resetFilterStyle(binding.tvFilterBlocked);
+        resetFilterStyle(binding.tvFilterUnblocked);
+        
+        // Highlight active
+        switch (activeFilter) {
+            case "All":
+                setActiveFilterStyle(binding.tvFilterAll);
+                break;
+            case "Blocked":
+                setActiveFilterStyle(binding.tvFilterBlocked);
+                break;
+            case "Unblocked":
+                setActiveFilterStyle(binding.tvFilterUnblocked);
+                break;
+        }
+    }
+
+    private void resetFilterStyle(TextView tv) {
+        tv.setBackgroundResource(R.drawable.bg_card);
+        tv.setTextColor(getResources().getColor(R.color.gray_400));
+    }
+
+    private void setActiveFilterStyle(TextView tv) {
+        tv.setBackgroundResource(R.drawable.bg_rounded_yellow);
+        tv.setTextColor(getResources().getColor(R.color.black));
+    }
+
+    private void observeViewModel() {
+        viewModel.getDisplayedUsers().observe(getViewLifecycleOwner(), users -> {
+            adapter.setUsers(users);
+        });
+        
+        viewModel.getIsLoading().observe(getViewLifecycleOwner(), isLoading -> {
+            // Show/hide progress bar if you have one
+        });
+        
+        viewModel.getErrorMessage().observe(getViewLifecycleOwner(), error -> {
+            if (error != null) {
+                Toast.makeText(getContext(), error, Toast.LENGTH_SHORT).show();
+            }
+        });
+        
+        viewModel.getSuccessMessage().observe(getViewLifecycleOwner(), msg -> {
+            if (msg != null) {
+                Toast.makeText(getContext(), msg, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    @Override
+    public void onBlock(UserProfile user) {
+        showBlockDialog(user);
+    }
+
+    @Override
+    public void onUnblock(UserProfile user) {
+        new AlertDialog.Builder(requireContext(), R.style.DarkDialogTheme)
+                .setTitle("Unblock User")
+                .setMessage("Are you sure you want to unblock " + user.getEmail() + "?")
+                .setPositiveButton("Unblock", (dialog, which) -> viewModel.unblockUser(user.getEmail()))
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private void showBlockDialog(UserProfile user) {
+        View dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_block_user, null);
+        AlertDialog dialog = new AlertDialog.Builder(requireContext())
+                .setView(dialogView)
+                .create();
+        
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().setBackgroundDrawableResource(android.R.color.transparent);
+        }
+
+        TextView tvTitle = dialogView.findViewById(R.id.tv_dialog_title);
+        TextView tvSubtitle = dialogView.findViewById(R.id.tv_dialog_subtitle);
+        EditText etReason = dialogView.findViewById(R.id.et_block_reason);
+        View btnCancel = dialogView.findViewById(R.id.btn_cancel_block);
+        View btnConfirm = dialogView.findViewById(R.id.btn_confirm_block);
+        View errorContainer = dialogView.findViewById(R.id.error_container);
+        TextView tvError = dialogView.findViewById(R.id.tv_error);
+
+        tvTitle.setText("Block " + user.getName());
+        tvSubtitle.setText("Provide a reason for blocking " + user.getEmail());
+
+        btnCancel.setOnClickListener(v -> dialog.dismiss());
+
+        btnConfirm.setOnClickListener(v -> {
+            String reason = etReason.getText().toString().trim();
+            if (reason.isEmpty()) {
+                errorContainer.setVisibility(View.VISIBLE);
+                tvError.setText("Block reason is required");
+            } else {
+                viewModel.blockUser(user.getEmail(), reason);
+                dialog.dismiss();
+            }
+        });
+
+        dialog.show();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/ui/passenger/PassengerHomeFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/passenger/PassengerHomeFragment.java
@@ -170,9 +170,10 @@ public class PassengerHomeFragment extends Fragment {
     }
 
     private void showBlockedDialog(String reason) {
+        String messageHtml = "You are currently <b>BLOCKED</b> and cannot order rides.<br><br><b><font color='#F44336'>Reason: " + reason + "</font></b>";
         new MaterialAlertDialogBuilder(requireContext(), R.style.DarkDialogTheme)
-                .setTitle("Access Restricted")
-                .setMessage("YOU ARE BLOCKED YOU CANT ORDER RIDE : " + reason)
+                .setTitle("Usage Restriction")
+                .setMessage(android.text.Html.fromHtml(messageHtml, android.text.Html.FROM_HTML_MODE_COMPACT))
                 .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
                 .show();
     }

--- a/mobile/app/src/main/java/com/example/mobile/ui/passenger/PassengerHomeFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/passenger/PassengerHomeFragment.java
@@ -150,9 +150,31 @@ public class PassengerHomeFragment extends Fragment {
             ((com.example.mobile.MainActivity) requireActivity()).openDrawer();
         });
 
-        binding.btnRequestRide.setOnClickListener(v -> openRequestRideDialog());
-        binding.btnLinkPassengers.setOnClickListener(v -> openLinkPassengersDialog());
+        binding.btnRequestRide.setOnClickListener(v -> {
+            String reason = viewModel.getBlockReason().getValue();
+            if (reason != null && !reason.isEmpty()) {
+                showBlockedDialog(reason);
+            } else {
+                openRequestRideDialog();
+            }
+        });
+        binding.btnLinkPassengers.setOnClickListener(v -> {
+            String reason = viewModel.getBlockReason().getValue();
+            if (reason != null && !reason.isEmpty()) {
+                showBlockedDialog(reason);
+            } else {
+                openLinkPassengersDialog();
+            }
+        });
 
+    }
+
+    private void showBlockedDialog(String reason) {
+        new MaterialAlertDialogBuilder(requireContext(), R.style.DarkDialogTheme)
+                .setTitle("Access Restricted")
+                .setMessage("YOU ARE BLOCKED YOU CANT ORDER RIDE : " + reason)
+                .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
+                .show();
     }
 
     private void setupFragmentResultListeners() {

--- a/mobile/app/src/main/java/com/example/mobile/ui/profile/DriverProfileFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/profile/DriverProfileFragment.java
@@ -73,6 +73,16 @@ public class DriverProfileFragment extends Fragment {
     }
 
     private void observeViewModel(){
+        // Observe blocked status
+        viewModel.getBlockReason().observe(getViewLifecycleOwner(), reason -> {
+            if (reason != null && !reason.isEmpty()) {
+                binding.tvBlockedWarning.setVisibility(View.VISIBLE);
+                binding.tvBlockedWarning.setText("YOU ARE BLOCKED YOU CANT BE ASSIGNED FOR RIDE\nReason: " + reason);
+            } else {
+                binding.tvBlockedWarning.setVisibility(View.GONE);
+            }
+        });
+
         // Observe profile data
         viewModel.getDriverProfileLiveData().observe(getViewLifecycleOwner(), profile -> {
             if (profile != null) {
@@ -89,6 +99,7 @@ public class DriverProfileFragment extends Fragment {
 
         // Load user profile
         viewModel.loadDriverProfile();
+        viewModel.checkIsBlocked();
     }
 
     private void displayDriverData(DriverProfileResponse profile) {

--- a/mobile/app/src/main/java/com/example/mobile/utils/ClientUtils.java
+++ b/mobile/app/src/main/java/com/example/mobile/utils/ClientUtils.java
@@ -1,6 +1,7 @@
 package com.example.mobile.utils;
 
 import com.example.mobile.BuildConfig;
+import com.example.mobile.services.AdminUserService;
 import com.example.mobile.services.DriverService;
 import com.example.mobile.services.PanicService;
 import com.example.mobile.services.ReviewService;
@@ -136,6 +137,11 @@ public class ClientUtils {
      * AdminService instance (admin pricing endpoints).
      */
     public static final AdminService adminService = retrofit.create(AdminService.class);
+
+    /**
+     * AdminUserService instance (admin user management).
+     */
+    public static final AdminUserService adminUserService = retrofit.create(AdminUserService.class);
 
     /**
      * SupportService instance (support chat endpoints).

--- a/mobile/app/src/main/java/com/example/mobile/viewmodels/AdminBlockUsersViewModel.java
+++ b/mobile/app/src/main/java/com/example/mobile/viewmodels/AdminBlockUsersViewModel.java
@@ -1,0 +1,217 @@
+package com.example.mobile.viewmodels;
+
+import android.app.Application;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.example.mobile.models.BlockUserRequest;
+import com.example.mobile.models.BlockUserResponse;
+import com.example.mobile.models.UserProfile;
+import com.example.mobile.utils.ClientUtils;
+import com.example.mobile.utils.SharedPreferencesManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AdminBlockUsersViewModel extends AndroidViewModel {
+    private static final String TAG = "AdminBlockUsersVM";
+    private final SharedPreferencesManager prefsManager;
+
+    private List<UserProfile> allUsers = new ArrayList<>();
+    private final MutableLiveData<List<UserProfile>> displayedUsers = new MutableLiveData<>();
+    private final MutableLiveData<Boolean> isLoading = new MutableLiveData<>(false);
+    private final MutableLiveData<String> errorMessage = new MutableLiveData<>();
+    private final MutableLiveData<String> successMessage = new MutableLiveData<>();
+
+    private String currentFilter = "All"; // All, Blocked, Unblocked
+    private String searchQuery = "";
+
+    public AdminBlockUsersViewModel(@NonNull Application application) {
+        super(application);
+        prefsManager = new SharedPreferencesManager(application.getApplicationContext());
+    }
+
+    public LiveData<List<UserProfile>> getDisplayedUsers() {
+        return displayedUsers;
+    }
+
+    public LiveData<Boolean> getIsLoading() {
+        return isLoading;
+    }
+
+    public LiveData<String> getErrorMessage() {
+        return errorMessage;
+    }
+
+    public LiveData<String> getSuccessMessage() {
+        return successMessage;
+    }
+
+    public void loadData() {
+        isLoading.setValue(true);
+        String token = "Bearer " + prefsManager.getToken();
+
+        // We need to fetch both blocked and unblocked to have a full list
+        fetchBlockedUsers(token, () -> {
+            fetchUnblockedUsers(token, () -> {
+                isLoading.setValue(false);
+                applyFiltersAndSearch();
+            });
+        });
+    }
+
+    private void fetchBlockedUsers(String token, Runnable onComplete) {
+        ClientUtils.adminUserService.getBlockedUsers(token).enqueue(new Callback<List<UserProfile>>() {
+            @Override
+            public void onResponse(Call<List<UserProfile>> call, Response<List<UserProfile>> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    List<UserProfile> blocked = response.body();
+                    blocked.forEach(u -> u.setBlocked(true));
+                    updateLocalUsers(blocked);
+                }
+                onComplete.run();
+            }
+
+            @Override
+            public void onFailure(Call<List<UserProfile>> call, Throwable t) {
+                Log.e(TAG, "Failed to fetch blocked users", t);
+                onComplete.run();
+            }
+        });
+    }
+
+    private void fetchUnblockedUsers(String token, Runnable onComplete) {
+        ClientUtils.adminUserService.getUnblockedUsers(token).enqueue(new Callback<List<UserProfile>>() {
+            @Override
+            public void onResponse(Call<List<UserProfile>> call, Response<List<UserProfile>> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    List<UserProfile> unblocked = response.body();
+                    unblocked.forEach(u -> u.setBlocked(false));
+                    updateLocalUsers(unblocked);
+                }
+                onComplete.run();
+            }
+
+            @Override
+            public void onFailure(Call<List<UserProfile>> call, Throwable t) {
+                Log.e(TAG, "Failed to fetch unblocked users", t);
+                onComplete.run();
+            }
+        });
+    }
+
+    private synchronized void updateLocalUsers(List<UserProfile> users) {
+        // Simple merge/update logic
+        for (UserProfile newUser : users) {
+            boolean found = false;
+            for (int i = 0; i < allUsers.size(); i++) {
+                if (allUsers.get(i).getEmail().equals(newUser.getEmail())) {
+                    allUsers.set(i, newUser);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                allUsers.add(newUser);
+            }
+        }
+    }
+
+    public void setFilter(String filter) {
+        this.currentFilter = filter;
+        applyFiltersAndSearch();
+    }
+
+    public void search(String query) {
+        this.searchQuery = query.toLowerCase().trim();
+        applyFiltersAndSearch();
+    }
+
+    private void applyFiltersAndSearch() {
+        List<UserProfile> filtered = new ArrayList<>(allUsers);
+
+        // Filter by status
+        if ("Blocked".equals(currentFilter)) {
+            filtered = filtered.stream().filter(UserProfile::isBlocked).collect(Collectors.toList());
+        } else if ("Unblocked".equals(currentFilter)) {
+            filtered = filtered.stream().filter(u -> !u.isBlocked()).collect(Collectors.toList());
+        }
+
+        // Search by email
+        if (!searchQuery.isEmpty()) {
+            filtered = filtered.stream()
+                    .filter(u -> u.getEmail().toLowerCase().contains(searchQuery))
+                    .collect(Collectors.toList());
+        }
+
+        displayedUsers.setValue(filtered);
+    }
+
+    public void blockUser(String email, String reason) {
+        isLoading.setValue(true);
+        String token = "Bearer " + prefsManager.getToken();
+        BlockUserRequest request = new BlockUserRequest(email, reason);
+
+        ClientUtils.adminUserService.blockUser(token, request).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                isLoading.setValue(false);
+                if (response.isSuccessful()) {
+                    successMessage.setValue("User blocked successfully");
+                    updateUserStatus(email, true);
+                } else {
+                    errorMessage.setValue("Failed to block user: " + response.code());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Void> call, Throwable t) {
+                isLoading.setValue(false);
+                errorMessage.setValue("Network error: " + t.getMessage());
+            }
+        });
+    }
+
+    public void unblockUser(String email) {
+        isLoading.setValue(true);
+        String token = "Bearer " + prefsManager.getToken();
+
+        ClientUtils.adminUserService.unblockUser(token, email).enqueue(new Callback<BlockUserResponse>() {
+            @Override
+            public void onResponse(Call<BlockUserResponse> call, Response<BlockUserResponse> response) {
+                isLoading.setValue(false);
+                if (response.isSuccessful()) {
+                    successMessage.setValue("User unblocked successfully");
+                    updateUserStatus(email, false);
+                } else {
+                    errorMessage.setValue("Failed to unblock user: " + response.code());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<BlockUserResponse> call, Throwable t) {
+                isLoading.setValue(false);
+                errorMessage.setValue("Network error: " + t.getMessage());
+            }
+        });
+    }
+
+    private void updateUserStatus(String email, boolean isBlocked) {
+        for (int i = 0; i < allUsers.size(); i++) {
+            if (allUsers.get(i).getEmail().equals(email)) {
+                allUsers.get(i).setBlocked(isBlocked);
+                break;
+            }
+        }
+        applyFiltersAndSearch();
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/viewmodels/DriverProfileViewModel.java
+++ b/mobile/app/src/main/java/com/example/mobile/viewmodels/DriverProfileViewModel.java
@@ -24,6 +24,7 @@ public class DriverProfileViewModel extends AndroidViewModel {
     private MutableLiveData<DriverProfileResponse> driverProfileLiveData;
     private MutableLiveData<Boolean> loadingLiveData;
     private MutableLiveData<String> errorLiveData;
+    private MutableLiveData<String> blockReasonLiveData;
 
     public DriverProfileViewModel(@NonNull Application application) {
         super(application);
@@ -32,9 +33,46 @@ public class DriverProfileViewModel extends AndroidViewModel {
         driverProfileLiveData = new MutableLiveData<>();
         loadingLiveData = new MutableLiveData<>();
         errorLiveData = new MutableLiveData<>();
+        blockReasonLiveData = new MutableLiveData<>();
     }
 
     // Getters for LiveData
+    public MutableLiveData<String> getBlockReason() {
+        return blockReasonLiveData;
+    }
+
+    // Check if driver is blocked
+    public void checkIsBlocked() {
+        Long userId = prefsManager.getUserId();
+        if (userId == null || userId <= 0) return;
+
+        String token = "Bearer " + prefsManager.getToken();
+        ClientUtils.userService.isUserBlocked(userId, token).enqueue(new Callback<okhttp3.ResponseBody>() {
+            @Override
+            public void onResponse(Call<okhttp3.ResponseBody> call, Response<okhttp3.ResponseBody> response) {
+                try {
+                    if (response.isSuccessful() && response.body() != null) {
+                        String reason = response.body().string();
+                        if (reason != null && !reason.trim().isEmpty()) {
+                            blockReasonLiveData.postValue(reason);
+                        } else {
+                            blockReasonLiveData.postValue("");
+                        }
+                    } else {
+                        blockReasonLiveData.postValue(""); // Assume not blocked
+                    }
+                } catch (Exception e) {
+                    blockReasonLiveData.postValue("");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<okhttp3.ResponseBody> call, Throwable t) {
+                Log.e(TAG, "Failed to check blocked status", t);
+                blockReasonLiveData.postValue("");
+            }
+        });
+    }
     public MutableLiveData<DriverProfileResponse> getDriverProfileLiveData() {
         return driverProfileLiveData;
     }

--- a/mobile/app/src/main/java/com/example/mobile/viewmodels/PassengerHomeViewModel.java
+++ b/mobile/app/src/main/java/com/example/mobile/viewmodels/PassengerHomeViewModel.java
@@ -16,6 +16,7 @@ import com.example.mobile.utils.ClientUtils;
 import com.example.mobile.utils.SharedPreferencesManager;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -42,9 +43,11 @@ public class PassengerHomeViewModel extends ViewModel {
     // LiveData for loading and errors
     private final MutableLiveData<Boolean> isLoadingLiveData = new MutableLiveData<>(false);
     private final MutableLiveData<String> errorMessageLiveData = new MutableLiveData<>();
-    private MutableLiveData<Boolean> rideRejected = new MutableLiveData<>();
+    private final MutableLiveData<Boolean> rideRejected = new MutableLiveData<>();
+    private final MutableLiveData<String> blockReasonLiveData = new MutableLiveData<>();
 
     public PassengerHomeViewModel(SharedPreferencesManager preferencesManager) {
+
         this.preferencesManager = preferencesManager;
         this.rideService = ClientUtils.rideService;
         this.vehicleService = ClientUtils.vehicleService;
@@ -53,6 +56,43 @@ public class PassengerHomeViewModel extends ViewModel {
     // Getters for LiveData
     public LiveData<List<VehicleLocationResponse>> getVehicles() {
         return vehiclesLiveData;
+    }
+
+    public LiveData<String> getBlockReason() {
+        return blockReasonLiveData;
+    }
+
+    // Check if user is blocked
+    public void checkIsBlocked() {
+        Long userId = preferencesManager.getUserId();
+        if (userId == null || userId <= 0) return;
+
+        String token = "Bearer " + preferencesManager.getToken();
+        ClientUtils.userService.isUserBlocked(userId, token).enqueue(new Callback<okhttp3.ResponseBody>() {
+            @Override
+            public void onResponse(Call<okhttp3.ResponseBody> call, Response<okhttp3.ResponseBody> response) {
+                try {
+                    if (response.isSuccessful() && response.body() != null) {
+                        String reason = response.body().string();
+                        if (reason != null && !reason.trim().isEmpty()) {
+                            blockReasonLiveData.postValue(reason);
+                        } else {
+                            blockReasonLiveData.postValue("");
+                        }
+                    } else {
+                        blockReasonLiveData.postValue(""); // Assume not blocked if error or null
+                    }
+                } catch (Exception e) {
+                    blockReasonLiveData.postValue("");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<okhttp3.ResponseBody> call, Throwable t) {
+                Log.e(TAG, "Failed to check blocked status", t);
+                blockReasonLiveData.postValue("");
+            }
+        });
     }
 
     public LiveData<VehicleCounts> getVehicleCounts() {

--- a/mobile/app/src/main/java/com/example/mobile/viewmodels/PassengerHomeViewModel.java
+++ b/mobile/app/src/main/java/com/example/mobile/viewmodels/PassengerHomeViewModel.java
@@ -51,6 +51,7 @@ public class PassengerHomeViewModel extends ViewModel {
         this.preferencesManager = preferencesManager;
         this.rideService = ClientUtils.rideService;
         this.vehicleService = ClientUtils.vehicleService;
+        checkIsBlocked();
     }
 
     // Getters for LiveData

--- a/mobile/app/src/main/res/layout/dialog_block_user.xml
+++ b/mobile/app/src/main/res/layout/dialog_block_user.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="@color/gray_900">
+
+    <TextView
+        android:id="@+id/tv_dialog_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Block User"
+        android:textColor="@color/red_500"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:id="@+id/tv_dialog_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Please provide a reason for blocking this user."
+        android:textColor="@color/gray_400"
+        android:textSize="14sp"
+        android:layout_marginBottom="16dp" />
+
+    <EditText
+        android:id="@+id/et_block_reason"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:background="@drawable/bg_auth_input"
+        android:gravity="top|start"
+        android:hint="Enter block reason..."
+        android:inputType="textMultiLine"
+        android:maxLength="500"
+        android:padding="14dp"
+        android:textColor="@color/white"
+        android:textColorHint="@color/gray_600"
+        android:textSize="14sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="This reason will be visible to the user."
+        android:textColor="@color/gray_400"
+        android:textSize="12sp"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="16dp" />
+
+    <LinearLayout
+        android:id="@+id/error_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_error_box"
+        android:padding="12dp"
+        android:layout_marginBottom="12dp"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/tv_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/red_500"
+            android:textSize="13sp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_cancel_block"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="Cancel"
+            android:textColor="@color/white"
+            android:textStyle="bold"
+            android:backgroundTint="@color/gray_700" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_confirm_block"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:text="Block"
+            android:textColor="@color/white"
+            android:textStyle="bold"
+            android:backgroundTint="@color/red_500" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/mobile/app/src/main/res/layout/fragment_admin_block_users.xml
+++ b/mobile/app/src/main/res/layout/fragment_admin_block_users.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/black">
+
+    <include
+        android:id="@+id/navbar"
+        layout="@layout/view_custom_navbar" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Block Users"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:textColor="@color/white"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Search box -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:background="@drawable/bg_card"
+            android:padding="12dp"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_search"
+                app:tint="@color/gray_400"/>
+
+            <EditText
+                android:id="@+id/et_search_user"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="12dp"
+                android:hint="Search by email..."
+                android:textColor="@color/white"
+                android:textColorHint="@color/gray_400"
+                android:background="@null"
+                android:imeOptions="actionSearch"
+                android:inputType="textEmailAddress"/>
+        </LinearLayout>
+
+        <!-- Filters -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="16dp">
+
+            <TextView
+                android:id="@+id/tv_filter_all"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Reset"
+                android:textColor="@color/black"
+                android:background="@drawable/bg_rounded_yellow"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="8dp"
+                android:layout_marginEnd="8dp"
+                android:textStyle="bold"/>
+
+            <TextView
+                android:id="@+id/tv_filter_blocked"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Blocked"
+                android:textColor="@color/gray_400"
+                android:background="@drawable/bg_card"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="8dp"
+                android:layout_marginEnd="8dp"
+                android:textStyle="bold"/>
+
+            <TextView
+                android:id="@+id/tv_filter_unblocked"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Unblocked"
+                android:textColor="@color/gray_400"
+                android:background="@drawable/bg_card"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="8dp"
+                android:textStyle="bold"/>
+        </LinearLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_users"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:listitem="@layout/item_block_user"/>
+
+    </LinearLayout>
+</LinearLayout>

--- a/mobile/app/src/main/res/layout/fragment_driver_profile.xml
+++ b/mobile/app/src/main/res/layout/fragment_driver_profile.xml
@@ -33,6 +33,18 @@
                 android:textStyle="bold"
                 android:layout_marginBottom="24dp"/>
 
+            <TextView
+                android:id="@+id/tv_blocked_warning"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="YOU ARE BLOCKED YOU CANT BE ASSIGNED FOR RIDE"
+                android:textColor="@color/red_500"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:gravity="center"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"/>
+
             <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 android:id="@+id/profileHeaderRoot"
                 android:layout_width="match_parent"

--- a/mobile/app/src/main/res/layout/item_block_user.xml
+++ b/mobile/app/src/main/res/layout/item_block_user.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="12dp"
+    android:layout_marginBottom="8dp"
+    android:background="@drawable/bg_card">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/iv_user_avatar"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:scaleType="centerCrop"
+        android:src="@drawable/avatar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.MaterialComponents.SmallComponent" />
+
+    <TextView
+        android:id="@+id/tv_user_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:text="John Doe"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toEndOf="@id/iv_user_avatar"
+        app:layout_constraintTop_toTopOf="@id/iv_user_avatar"
+        app:layout_constraintEnd_toStartOf="@id/btn_block_action" />
+
+    <TextView
+        android:id="@+id/tv_user_email"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:text="john.doe@example.com"
+        android:textColor="@color/gray_400"
+        android:textSize="14sp"
+        app:layout_constraintStart_toEndOf="@id/iv_user_avatar"
+        app:layout_constraintTop_toBottomOf="@id/tv_user_name"
+        app:layout_constraintEnd_toStartOf="@id/btn_block_action" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_block_action"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Block"
+        android:textColor="@color/white"
+        app:backgroundTint="@color/red_500"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        style="@style/Widget.MaterialComponents.Button.TextButton" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/app/src/main/res/menu/menu_drawer_admin.xml
+++ b/mobile/app/src/main/res/menu/menu_drawer_admin.xml
@@ -40,6 +40,10 @@
             android:id="@+id/nav_admin_panic"
             android:icon="@drawable/ic_menu_panic"
             android:title="Panic Alerts" />
+        <item
+            android:id="@+id/nav_admin_block_users"
+            android:icon="@drawable/ic_person"
+            android:title="Block Users" />
     </group>
     <item android:title="Account">
         <menu>

--- a/mobile/app/src/main/res/navigation/mobile_navigation.xml
+++ b/mobile/app/src/main/res/navigation/mobile_navigation.xml
@@ -298,6 +298,12 @@
         tools:layout="@layout/fragment_admin_panic" />
 
     <fragment
+        android:id="@+id/nav_admin_block_users"
+        android:name="com.example.mobile.ui.admin.AdminBlockUsersFragment"
+        android:label="Block Users"
+        tools:layout="@layout/fragment_admin_block_users" />
+
+    <fragment
         android:id="@+id/nav_passenger_history"
         android:name="com.example.mobile.ui.passenger.PassengerHistoryFragment"
         android:label="Ride History"


### PR DESCRIPTION
# Pull Request Description: Task 2.12. Blocking users and leaving notes

## Description of changes
Implemented functionality that allows administrators to block/unblock users (drivers and passengers) at any time, as well as leave an explanation (note) for the block.

Main functionalities include:
1. Blocking drivers:
   - An administrator can block or unblock a driver in the system.
   - Blocked drivers become unavailable for automatic or manual assignment of new rides.
   - The administrator's note is displayed directly on the driver's profile.
2. Blocking passengers:
   - An administrator can block or unblock a passenger.
   - Blocked passengers lose the ability to create and order new rides.
   - When attempting to order a ride, a message with a note explaining the reason for the block is displayed on the passenger's screen.
3. Leaving notes:
   - Added a form in the admin panel that allows entering a text note during the user blocking process.

## Technical changes
- Database: Added fields for block status (e.g., `is_blocked`, `status`) and a field for entering the note text (e.g., `blocking_note`) in the appropriate user tables (or extended profiles for drivers and passengers).
- Backend:
  - Created/updated API endpoints for user administration (blocking/unblocking).
  - Implemented validation and user status checks within the ride assignment service (to avoid blocked drivers).
  - Implemented a restriction on the ride creation endpoint (returns an error and the note if the passenger is blocked).
- Frontend:
  - Admin panel: Added a block option with a modal window for entering a note.
  - Driver profile: Implemented the display of the block message and the accompanying note.
  - Passenger UI: Added a restrictive message display with the administrator's note when a blocked user attempts to initiate a new ride.
