### PR TITLE
driver opens link from gmail

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,135 @@
+# Gemini project context
+
+This Android project uses Java and follows a ViewModel + LiveData + Retrofit pattern.
+
+## Core structure
+
+Packages:
+- `Domain` — UI/presentation models used by adapters and fragments.
+- `models` — API/request/response models mapped directly to backend payloads.
+- `services` — Retrofit interfaces.
+- `ui` — Fragments, activities, adapters, dialogs, and other UI classes.
+- `utils` — Helpers such as `ClientUtils`, `SharedPreferencesManager`, `NavbarHelper`, `ListViewHelper`.
+- `viewmodels` — `ViewModel` and `AndroidViewModel` classes that own state, filtering, searching, and API calls.
+
+## Technology and conventions
+
+- Language: Java only unless explicitly asked otherwise.
+- UI: XML layouts, ViewBinding, Material components, custom drawables.
+- Networking: Retrofit services accessed through `ClientUtils`.
+- State: `LiveData` and `MutableLiveData`.
+- Auth: bearer token from `SharedPreferencesManager`.
+- Async work: Retrofit `enqueue(...)` callbacks.
+- Logging: use `Log.d`, `Log.e` with a `TAG` constant.
+- Fragments must use `getViewLifecycleOwner()` when observing LiveData.
+- Fragments must set binding to null in `onDestroyView()`.
+
+## Architecture rules
+
+### ViewModels
+- Keep business logic, filtering, searching, loading states, and API calls inside ViewModels.
+- Expose immutable `LiveData` to UI.
+- Keep `MutableLiveData` private.
+- Store raw source data internally and derive filtered/displayed data from it.
+- If multiple API calls are needed, manage completion carefully and update loading state only when all calls finish.
+
+### Fragments
+- Keep Fragments thin.
+- Initialize adapters in `onViewCreated()`.
+- Observe ViewModel state in one method like `observeViewModel()`.
+- Convert backend models to domain/UI models only if that mapping is presentation-specific.
+- Do not call Retrofit services directly from fragments.
+- Use helper classes like `NavbarHelper` and `ListViewHelper` if they already exist in the screen.
+
+### Adapters
+- Follow the existing adapter style in the project.
+- If a screen uses `ListView`, use a custom `ArrayAdapter` with the ViewHolder pattern.
+- If a screen uses `RecyclerView`, use the standard `RecyclerView.Adapter` pattern.
+- Do not switch ListView to RecyclerView or vice versa unless explicitly requested.
+- Keep item binding null-safe and lightweight.
+
+## Current screen pattern example: admin drivers
+
+### ViewModel pattern
+Example: `AdminDriversViewModel`
+- Holds `allDrivers` as the raw source of truth.
+- Holds `driverStatsMap` for extra per-item data.
+- Exposes:
+  - `getDisplayedDrivers()`
+  - `getLoadingLiveData()`
+  - `getErrorLiveData()`
+  - `getToastMessage()`
+- Supports:
+  - `loadAllDrivers()`
+  - `filterByStatus(String status)`
+  - `search(String query)`
+  - `createDriver(...)`
+
+### Fragment pattern
+Example: `AdminDriversFragment`
+- Uses `FragmentAdminDriversBinding`.
+- Sets up navbar in `onCreateView()`.
+- Creates `AdminDriverAdapter` in `onViewCreated()`.
+- Observes displayed data and maps `DriverResponse` objects to `DriverInfoCard`.
+- Handles UI-only actions such as filter button styling, search click, and opening dialogs.
+
+### Domain model pattern
+Example: `DriverInfoCard`
+- This is a presentation model for the adapter.
+- It may combine multiple backend models into one UI object.
+- It should stay simple and be used for displaying list/card data, not for API calls.
+
+### Adapter pattern
+Example: `AdminDriverAdapter`
+- Extends `ArrayAdapter<DriverInfoCard>`.
+- Uses an inner `ViewHolder` for performance.
+- Inflates `R.layout.driver_card_info`.
+- Binds avatar, name, email, vehicle info, status, rating, total rides, and earnings.
+- Supports `setDrivers(List<DriverInfoCard>)` and refreshes via `notifyDataSetChanged()`.
+
+## Important project rules for Gemini
+
+### Do
+- Follow the existing package structure.
+- Reuse existing naming conventions.
+- Generate small, focused changes.
+- Keep code defensive and null-safe.
+- Preserve the current UI architecture.
+- Use existing helpers, drawables, and binding classes when possible.
+
+### Do not
+- Introduce Kotlin, Compose, or Navigation Component unless explicitly requested.
+- Rewrite entire files when only a method or class section is needed.
+- Move business logic into fragments or adapters.
+- Invent new services or data layers if an existing Retrofit service can be extended.
+- Change adapter type unless the user asks for it.
+
+## When generating new code
+
+### New ViewModel
+- Extend `AndroidViewModel` if application context is needed.
+- Add private `MutableLiveData` fields and public `LiveData` getters.
+- Use Retrofit callbacks.
+- Keep list filtering/search inside the ViewModel.
+
+### New Fragment
+- Use ViewBinding.
+- Initialize adapter, listeners, and observers separately.
+- Keep the fragment as a UI controller only.
+- Map models to domain objects only if needed for display.
+
+### New Adapter
+- Match the list technology already used by that screen.
+- Use ViewHolder pattern.
+- Avoid expensive work inside `getView()` or `onBindViewHolder()`.
+
+### New layout
+- Use XML layouts.
+- Follow existing naming patterns like `fragment_<name>.xml` and `item_<name>.xml`.
+- Reuse existing colors, drawables, and Material styles.
+
+## Response style expected from Gemini
+- Prefer code that fits into the current codebase without refactoring unrelated parts.
+- When asked for a new feature, generate only the necessary classes, methods, and XML.
+- If a change affects multiple files, keep the solution minimal and consistent.
+- If a detail is ambiguous, follow the patterns already used in the project.

--- a/backend/src/main/java/com/team27/lucky3/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/config/WebSecurityConfig.java
@@ -72,6 +72,8 @@ public class WebSecurityConfig {
                 .requestMatchers("/api/vehicles/active").permitAll() // 2.1.1 Public map
                 .requestMatchers("/api/vehicles/prices").permitAll() // Public vehicle pricing
                 .requestMatchers("/api/rides/estimate").permitAll()  // 2.1.2 Public estimate
+                .requestMatchers("/api/drivers/driver-activation/password").permitAll() // Public driver activation
+                .requestMatchers(HttpMethod.GET, "/api/drivers/*/stats").permitAll() // Public driver stats
                 .requestMatchers("/api/users/*/profile-image").permitAll()
                 .requestMatchers("/api/reviews/validate-token").permitAll() // Public review token validation
                 .requestMatchers("/api/reviews/with-token").permitAll() // Public review submission with token

--- a/backend/src/main/java/com/team27/lucky3/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/controller/AuthController.java
@@ -115,7 +115,7 @@ public class AuthController {
     }
 
     @Operation(summary = "Set initial driver password", description = "Driver sets password via activation token from email link", security = {})
-    @PutMapping(value = "/driver-activation/password", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/driver-activation/password", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> setInitialPassword(@Valid @RequestBody SetInitialPassword initialPassword) {
         authService.activateDriverWithPassword(initialPassword.getToken(), initialPassword.getPassword());
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/team27/lucky3/backend/controller/DriverController.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/controller/DriverController.java
@@ -39,6 +39,7 @@ import java.util.List;
 public class DriverController {
     private final DriverService driverService;
     private final DriverChangeRequestService driverChangeRequestService;
+    private final PasswordEncoder passwordEncoder;
 
     @Operation(summary = "Toggle driver status", description = "Set driver online/offline (DRIVER only)")
     @PreAuthorize("hasRole('DRIVER')")
@@ -79,9 +80,7 @@ public class DriverController {
 
     @Operation(summary = "Set initial driver password", description = "Driver sets password via activation token (public, no auth required)", security = {})
     @PostMapping(value = "/driver-activation/password", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> setInitialPassword(@Valid @RequestBody SetInitialPassword initialPassword,
-                                                   PasswordEncoder passwordEncoder,
-                                                   DriverService driverService) {
+    public ResponseEntity<Void> setInitialPassword(@Valid @RequestBody SetInitialPassword initialPassword) {
         driverService.activateDriverWithPassword(initialPassword.getToken(), initialPassword.getPassword(), passwordEncoder);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/team27/lucky3/backend/service/impl/DriverServiceImpl.java
+++ b/backend/src/main/java/com/team27/lucky3/backend/service/impl/DriverServiceImpl.java
@@ -49,6 +49,9 @@ public class DriverServiceImpl implements DriverService {
     private final EmailService emailService;
     private final ImageService imageService;
 
+    // Deep link base URL. 
+    // For Android App Links to work automatically without a browser prompt, 
+    // this should eventually be a real verified HTTPS domain.
     private final String activationBaseUrl = "http://localhost:4200/driver/set-password?token=";
 
     @Override

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -44,6 +44,18 @@
             </intent-filter>
 
             <nav-graph android:value="@navigation/mobile_navigation" />
+
+            <!-- Deep Link for Driver Activation -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http"
+                    android:host="localhost"
+                    android:port="4200"
+                    android:pathPrefix="/driver/set-password"
+                    tools:ignore="AppLinkUrlError" />
+            </intent-filter>
         </activity>
 
         <!-- FCM Push Notification Service -->

--- a/mobile/app/src/main/java/com/example/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/example/mobile/MainActivity.java
@@ -137,8 +137,19 @@ public class MainActivity extends AppCompatActivity {
 
             // Only navigate on fresh start — NOT on configuration changes (e.g. orientation)
             if (savedInstanceState == null) {
-                // Restore session
-                checkSession(navController);
+                Intent intent = getIntent();
+                boolean isDeepLink = intent != null && intent.getData() != null;
+                boolean navigated = false;
+
+                // Restore session if not a deep link
+                if (!isDeepLink) {
+                    navigated = checkSession(navController);
+                }
+
+                // If no session navigation and it's a deep link, handle it explicitly
+                if (!navigated && isDeepLink) {
+                    navController.handleDeepLink(intent);
+                }
 
                 // Handle FCM deep-link if app was launched from a notification
                 handleFcmDeepLink(getIntent());
@@ -153,7 +164,7 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    private void checkSession(NavController navController) {
+    private boolean checkSession(NavController navController) {
         String token = sharedPreferencesManager.getToken();
         if (token != null && !token.isEmpty()) {
             String role = sharedPreferencesManager.getUserRole();
@@ -176,8 +187,10 @@ public class MainActivity extends AppCompatActivity {
                 } else if ("PASSENGER".equals(role)) {
                     navController.navigate(R.id.nav_passenger_home, null, sessionNavOptions);
                 }
+                return true;
             }
         }
+        return false;
     }
 
     @Override

--- a/mobile/app/src/main/java/com/example/mobile/models/SetInitialPassword.java
+++ b/mobile/app/src/main/java/com/example/mobile/models/SetInitialPassword.java
@@ -1,0 +1,47 @@
+package com.example.mobile.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Model for setting initial driver password during account activation.
+ */
+public class SetInitialPassword {
+    @SerializedName("token")
+    private String token;
+
+    @SerializedName("password")
+    private String password;
+
+    @SerializedName("confirmPassword")
+    private String confirmPassword;
+
+    public SetInitialPassword(String token, String password, String confirmPassword) {
+        this.token = token;
+        this.password = password;
+        this.confirmPassword = confirmPassword;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/services/DriverService.java
+++ b/mobile/app/src/main/java/com/example/mobile/services/DriverService.java
@@ -101,4 +101,10 @@ public interface DriverService {
             @Header("Authorization") String token
     );
 
+    /**
+     * Activate driver account by setting initial password
+     */
+    @POST("api/drivers/driver-activation/password")
+    Call<Void> activateDriver(@Body com.example.mobile.models.SetInitialPassword request);
+
 }

--- a/mobile/app/src/main/java/com/example/mobile/ui/auth/DriverActivationFragment.java
+++ b/mobile/app/src/main/java/com/example/mobile/ui/auth/DriverActivationFragment.java
@@ -1,0 +1,94 @@
+package com.example.mobile.ui.auth;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.Navigation;
+
+import com.example.mobile.R;
+import com.example.mobile.databinding.FragmentDriverActivationBinding;
+import com.example.mobile.viewmodels.DriverActivationViewModel;
+
+public class DriverActivationFragment extends Fragment {
+
+    private FragmentDriverActivationBinding binding;
+    private DriverActivationViewModel viewModel;
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        binding = FragmentDriverActivationBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        viewModel = new ViewModelProvider(this).get(DriverActivationViewModel.class);
+
+        if (getArguments() != null) {
+            String token = getArguments().getString("token", "");
+            viewModel.setToken(token);
+        }
+
+        setupListeners();
+        observeViewModel();
+    }
+
+    private void setupListeners() {
+        binding.passwordEditText.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) { viewModel.setPassword(s.toString()); }
+            @Override public void afterTextChanged(Editable s) {}
+        });
+
+        binding.confirmPasswordEditText.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void onTextChanged(CharSequence s, int start, int before, int count) { viewModel.setConfirmPassword(s.toString()); }
+            @Override public void afterTextChanged(Editable s) {}
+        });
+
+        binding.activateButton.setOnClickListener(v -> viewModel.activateAccount());
+    }
+
+    private void observeViewModel() {
+        viewModel.getIsLoading().observe(getViewLifecycleOwner(), isLoading -> {
+            binding.activateButton.setEnabled(!isLoading);
+            binding.activateButton.setText(isLoading ? "" : "Activate Account");
+            binding.loadingProgress.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        });
+
+        viewModel.getPasswordError().observe(getViewLifecycleOwner(), error -> binding.passwordInputLayout.setError(error));
+        viewModel.getConfirmPasswordError().observe(getViewLifecycleOwner(), error -> binding.confirmPasswordInputLayout.setError(error));
+
+        viewModel.getErrorMessage().observe(getViewLifecycleOwner(), error -> {
+            if (error != null) {
+                binding.errorContainer.setVisibility(View.VISIBLE);
+                binding.errorText.setText(error);
+            } else {
+                binding.errorContainer.setVisibility(View.GONE);
+            }
+        });
+
+        viewModel.getActivationSuccess().observe(getViewLifecycleOwner(), success -> {
+            if (success) {
+                Toast.makeText(requireContext(), "Account activated! Please log in.", Toast.LENGTH_LONG).show();
+                Navigation.findNavController(requireView()).navigate(R.id.nav_login);
+            }
+        });
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/mobile/app/src/main/java/com/example/mobile/viewmodels/DriverActivationViewModel.java
+++ b/mobile/app/src/main/java/com/example/mobile/viewmodels/DriverActivationViewModel.java
@@ -1,0 +1,138 @@
+package com.example.mobile.viewmodels;
+
+import android.app.Application;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.example.mobile.models.SetInitialPassword;
+import com.example.mobile.utils.ClientUtils;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * ViewModel for DriverActivationFragment.
+ * Manages driver account activation (initial password set) state and handles API calls.
+ */
+public class DriverActivationViewModel extends AndroidViewModel {
+
+    private static final String TAG = "DriverActivationViewModel";
+
+    // Token state
+    private final MutableLiveData<String> token = new MutableLiveData<>("");
+
+    // Input fields state
+    private final MutableLiveData<String> password = new MutableLiveData<>("");
+    private final MutableLiveData<String> confirmPassword = new MutableLiveData<>("");
+
+    // UI state
+    private final MutableLiveData<Boolean> isLoading = new MutableLiveData<>(false);
+    private final MutableLiveData<String> errorMessage = new MutableLiveData<>(null);
+    private final MutableLiveData<Boolean> activationSuccess = new MutableLiveData<>(false);
+
+    // Validation errors
+    private final MutableLiveData<String> passwordError = new MutableLiveData<>(null);
+    private final MutableLiveData<String> confirmPasswordError = new MutableLiveData<>(null);
+
+    public DriverActivationViewModel(@NonNull Application application) {
+        super(application);
+    }
+
+    // ========================== LiveData Getters ==========================
+
+    public LiveData<String> getToken() { return token; }
+    public LiveData<Boolean> getIsLoading() { return isLoading; }
+    public LiveData<String> getErrorMessage() { return errorMessage; }
+    public LiveData<Boolean> getActivationSuccess() { return activationSuccess; }
+    public LiveData<String> getPasswordError() { return passwordError; }
+    public LiveData<String> getConfirmPasswordError() { return confirmPasswordError; }
+
+    // ========================== Setters ==========================
+
+    public void setToken(String value) { token.setValue(value); }
+
+    public void setPassword(String value) {
+        password.setValue(value);
+        passwordError.setValue(null);
+    }
+
+    public void setConfirmPassword(String value) {
+        confirmPassword.setValue(value);
+        confirmPasswordError.setValue(null);
+    }
+
+    // ========================== Logic ==========================
+
+    private boolean validateInputs() {
+        boolean isValid = true;
+        String pass = password.getValue();
+        String conf = confirmPassword.getValue();
+
+        if (pass == null || pass.isEmpty()) {
+            passwordError.setValue("Password is required");
+            isValid = false;
+        } else if (pass.length() < 8) {
+            passwordError.setValue("Password must be at least 8 characters");
+            isValid = false;
+        }
+
+        if (conf == null || conf.isEmpty()) {
+            confirmPasswordError.setValue("Please confirm your password");
+            isValid = false;
+        } else if (!conf.equals(pass)) {
+            confirmPasswordError.setValue("Passwords do not match");
+            isValid = false;
+        }
+
+        return isValid;
+    }
+
+    public void activateAccount() {
+        errorMessage.setValue(null);
+        activationSuccess.setValue(false);
+
+        String tokenValue = token.getValue();
+        if (tokenValue == null || tokenValue.trim().isEmpty()) {
+            errorMessage.setValue("Activation token is missing. Please open the link from your email again.");
+            return;
+        }
+
+        if (!validateInputs()) {
+            return;
+        }
+
+        isLoading.setValue(true);
+
+        SetInitialPassword request = new SetInitialPassword(
+                tokenValue.trim(),
+                password.getValue(),
+                confirmPassword.getValue()
+        );
+
+        ClientUtils.driverService.activateDriver(request).enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(@NonNull Call<Void> call, @NonNull Response<Void> response) {
+                isLoading.postValue(false);
+                if (response.isSuccessful()) {
+                    Log.d(TAG, "Account activation successful");
+                    activationSuccess.postValue(true);
+                } else {
+                    errorMessage.postValue("Activation failed. The link may be expired or invalid.");
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Void> call, @NonNull Throwable t) {
+                isLoading.postValue(false);
+                errorMessage.postValue("Connection error. Please try again.");
+            }
+        });
+    }
+
+    public void clearError() { errorMessage.setValue(null); }
+}

--- a/mobile/app/src/main/res/layout/fragment_driver_activation.xml
+++ b/mobile/app/src/main/res/layout/fragment_driver_activation.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/gray_900"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="24dp">
+
+        <!-- Logo/Icon -->
+        <FrameLayout
+            android:id="@+id/icon_container"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginTop="64dp"
+            android:background="@drawable/bg_icon_box_yellow"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <ImageView
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_lock"
+                app:tint="@color/gray_900"
+                android:contentDescription="Activate account" />
+        </FrameLayout>
+
+        <!-- Title -->
+        <TextView
+            android:id="@+id/title_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Activate Account"
+            android:textColor="@color/white"
+            android:textSize="28sp"
+            android:textStyle="bold"
+            android:layout_marginTop="16dp"
+            app:layout_constraintTop_toBottomOf="@id/icon_container"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- Subtitle -->
+        <TextView
+            android:id="@+id/subtitle_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Please set your password to activate your driver account"
+            android:textColor="@color/gray_400"
+            android:textSize="16sp"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            app:layout_constraintTop_toBottomOf="@id/title_text"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- Form Container -->
+        <LinearLayout
+            android:id="@+id/form_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="32dp"
+            app:layout_constraintTop_toBottomOf="@id/subtitle_text">
+
+            <!-- Password Input -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/password_input_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="New Password"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                app:boxStrokeColor="@color/input_box_stroke_color"
+                app:boxStrokeErrorColor="@color/red_500"
+                app:hintTextColor="@color/yellow_500"
+                app:startIconDrawable="@drawable/ic_lock"
+                app:startIconTint="@color/gray_400"
+                app:endIconMode="password_toggle"
+                app:endIconTint="@color/gray_400"
+                app:errorEnabled="true">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/password_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/white"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Confirm Password Input -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/confirm_password_input_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="Confirm Password"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                app:boxStrokeColor="@color/input_box_stroke_color"
+                app:boxStrokeErrorColor="@color/red_500"
+                app:hintTextColor="@color/yellow_500"
+                app:startIconDrawable="@drawable/ic_lock"
+                app:startIconTint="@color/gray_400"
+                app:endIconMode="password_toggle"
+                app:endIconTint="@color/gray_400"
+                app:errorEnabled="true">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/confirm_password_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/white"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Error Box -->
+            <LinearLayout
+                android:id="@+id/error_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/bg_error_box"
+                android:padding="12dp"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:visibility="gone">
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@drawable/ic_error"
+                    app:tint="@color/red_500" />
+
+                <TextView
+                    android:id="@+id/error_text"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:textColor="@color/red_500"
+                    android:textSize="14sp" />
+            </LinearLayout>
+
+            <!-- Activate Button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/activate_button"
+                android:layout_width="match_parent"
+                android:layout_height="56dp"
+                android:layout_marginTop="24dp"
+                android:text="Activate Account"
+                android:textColor="@color/gray_900"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                app:backgroundTint="@color/yellow_500"
+                app:cornerRadius="12dp" />
+
+            <ProgressBar
+                android:id="@+id/loading_progress"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:layout_marginTop="-40dp"
+                android:visibility="gone"
+                android:indeterminateTint="@color/gray_900" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/mobile/app/src/main/res/navigation/mobile_navigation.xml
+++ b/mobile/app/src/main/res/navigation/mobile_navigation.xml
@@ -88,6 +88,33 @@
         tools:layout="@layout/fragment_reset_password_success" />
 
     <fragment
+        android:id="@+id/fragment_driver_activation"
+        android:name="com.example.mobile.ui.auth.DriverActivationFragment"
+        android:label="Driver Activation"
+        tools:layout="@layout/fragment_driver_activation">
+
+        <argument
+            android:name="token"
+            app:argType="string" />
+        <deepLink
+            android:id="@+id/deepLink"
+            app:uri="http://localhost:4200/driver/set-password?token={token}" />
+
+    </fragment>
+    <!--
+    <fragment
+        android:id="@+id/nav_driver_activation"
+        android:name="com.example.mobile.ui.auth.DriverActivationFragment"
+        android:label="Activate Account"
+        tools:layout="@layout/fragment_driver_activation">
+
+        <deep-link
+            app:uri="http://localhost:4200/driver/set-password?token={token}" />
+        <deep-link
+            app:uri="https://localhost:4200/driver/set-password?token={token}" />
+    </fragment> -->
+
+    <fragment
         android:id="@+id/nav_register_verification"
         android:name="com.example.mobile.ui.auth.RegisterVerificationFragment"
         android:label="Verify Email"


### PR DESCRIPTION
# PR: Deep Link Implementation for Driver Registration and Activation (Task 2.2.3)

## Description of Changes
This Pull Request implements Deep Linking support within the mobile application as part of task **2.2.3 Driver Registration (Student1)**. 

Previously, clicking the activation link only opened the default home screen of the app. With these changes, when a driver clicks the one-time activation link received via email, the mobile app automatically intercepts the request and navigates the user directly to the activation screen (`fragment_driver_activation`) to set their initial password.

## Key Changes (Per 2.2.3 Requirements):
- **Intent Filter Configuration:** Updated the navigation graph and `AndroidManifest.xml` to correctly catch the specific URL scheme and path (e.g., `http://localhost:4200/driver/set-password`).
- **Direct Fragment Routing:** Hooked up the deep link to the Jetpack Navigation component so that it automatically opens `fragment_driver_activation` instead of resting on the default `MainActivity` UI.
- **Application State Handling:** Ensured the deep link is processed correctly regardless of whether the app was completely closed (cold start) or already running in the background.

## Enabled Workflow:
1. The administrator creates a driver account (including both driver details and specific vehicle details: model, type, license plates, number of seats, and baby/pet transport capabilities).
2. The system automatically sends an email with a one-time activation link (valid for 24 hours).
3. Clicking the link on a mobile device **opens the mobile application directly to the password setup screen**.
4. The driver enters their new password in two fields (password and confirmation). Upon successful setup, the activation link becomes invalid, and the driver can subsequently log into the system using their email and new password.